### PR TITLE
Change permissions of target directory

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -227,3 +227,6 @@ if [[ "$*" =~ --json || "$*" =~ --app ]]; then
 else
     echo $JSON | tera --template /srtool/templates/output.txt --stdin --env --fail-on-collision
 fi
+
+# change permissions
+chmod -R 0777 $RUNTIME_DIR/target


### PR DESCRIPTION
The `target` directory create by `root`, it's hard to delete from the host.