### PR TITLE
wasm-gc is deprecated.

### DIFF
--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -10,7 +10,3 @@ echo "*** Initializing WASM build environment"
 # For now, only nightlies will work.
 # rustup toolchain install $RUSTC_VERSION
 rustup target add wasm32-unknown-unknown --toolchain $RUSTC_VERSION
-
-# Install wasm-gc. It's useful for stripping slimming down wasm binaries.
-command -v wasm-gc || \
-	cargo +$RUSTC_VERSION install --git https://github.com/alexcrichton/wasm-gc --force


### PR DESCRIPTION
Tool isn't referenced and the functionality is subsumed into
rustc and wasm-bingen ( https://github.com/alexcrichton/wasm-gc ).
By not having to build it the docker image builds a tad faster too and we don't have to see lots of warnings about old rust code that we don't care about.