### PR TITLE
feat: add `parachain_system.authorize_upgrade` call hash to output

### DIFF
--- a/scripts/analyse.sh
+++ b/scripts/analyse.sh
@@ -4,7 +4,8 @@ WASM=$1
 WASM_FULLPATH=/build/$WASM
 
 SZ=`du -sb $WASM_FULLPATH | awk '{print $1}'`
-PROP=`subwasm -j info $WASM_FULLPATH | jq -r .proposal_hash`
+SET_CODE_PROP=`subwasm -j info $Z_WASM | jq -r .proposal_hash`
+AUTHORIZE_UPGRADE_PROP=`subwasm -j info $Z_WASM | jq -r .parachain_authorize_upgrade_hash`
 MULTIHASH=`subwasm -j info $WASM_FULLPATH | jq -r .ipfs_hash`
 SHA256=0x`shasum -a 256 $WASM_FULLPATH | awk '{print $1}'`
 TMSP=$(date --utc +%FT%TZ -d @$(stat -c "%Y" $WASM_FULLPATH))
@@ -14,7 +15,8 @@ SUBWASM=`subwasm -j info $WASM_FULLPATH`
 JSON=$( jq -n \
     --arg tmsp "$TMSP" \
     --arg size "$SZ" \
-    --arg prop "$PROP" \
+    --arg set_code_prop "$SET_CODE_PROP" \
+    --arg authorize_upgrade_prop "$AUTHORIZE_UPGRADE_PROP" \
     --arg blake2_256 "$BLAKE2_256" \
     --arg ipfs "$MULTIHASH" \
     --arg sha256 "$SHA256" \
@@ -23,7 +25,8 @@ JSON=$( jq -n \
     '{
         tmsp: $tmsp,
         size: $size,
-        prop: $prop,
+        set_code_prop: $set_code_prop,
+        authorize_upgrade_prop: $authorize_upgrade_prop,
         blake2_256: $blake2_256,
         ipfs: $ipfs,
         sha256: $sha256,

--- a/scripts/analyse.sh
+++ b/scripts/analyse.sh
@@ -4,7 +4,7 @@ WASM=$1
 WASM_FULLPATH=/build/$WASM
 
 SZ=`du -sb $WASM_FULLPATH | awk '{print $1}'`
-SET_CODE_PROP=`subwasm -j info $Z_WASM | jq -r .proposal_hash`
+PROP=`subwasm -j info $Z_WASM | jq -r .proposal_hash`
 AUTHORIZE_UPGRADE_PROP=`subwasm -j info $Z_WASM | jq -r .parachain_authorize_upgrade_hash`
 MULTIHASH=`subwasm -j info $WASM_FULLPATH | jq -r .ipfs_hash`
 SHA256=0x`shasum -a 256 $WASM_FULLPATH | awk '{print $1}'`
@@ -15,7 +15,7 @@ SUBWASM=`subwasm -j info $WASM_FULLPATH`
 JSON=$( jq -n \
     --arg tmsp "$TMSP" \
     --arg size "$SZ" \
-    --arg set_code_prop "$SET_CODE_PROP" \
+    --arg prop "$PROP" \
     --arg authorize_upgrade_prop "$AUTHORIZE_UPGRADE_PROP" \
     --arg blake2_256 "$BLAKE2_256" \
     --arg ipfs "$MULTIHASH" \
@@ -25,7 +25,7 @@ JSON=$( jq -n \
     '{
         tmsp: $tmsp,
         size: $size,
-        set_code_prop: $set_code_prop,
+        prop: $prop,
         authorize_upgrade_prop: $authorize_upgrade_prop,
         blake2_256: $blake2_256,
         ipfs: $ipfs,

--- a/scripts/analyse.sh
+++ b/scripts/analyse.sh
@@ -4,8 +4,8 @@ WASM=$1
 WASM_FULLPATH=/build/$WASM
 
 SZ=`du -sb $WASM_FULLPATH | awk '{print $1}'`
-PROP=`subwasm -j info $Z_WASM | jq -r .proposal_hash`
-AUTHORIZE_UPGRADE_PROP=`subwasm -j info $Z_WASM | jq -r .parachain_authorize_upgrade_hash`
+PROP=`subwasm -j info $WASM_FULLPATH | jq -r .proposal_hash`
+AUTHORIZE_UPGRADE_PROP=`subwasm -j info $WASM_FULLPATH | jq -r .parachain_authorize_upgrade_hash`
 MULTIHASH=`subwasm -j info $WASM_FULLPATH | jq -r .ipfs_hash`
 SHA256=0x`shasum -a 256 $WASM_FULLPATH | awk '{print $1}'`
 TMSP=$(date --utc +%FT%TZ -d @$(stat -c "%Y" $WASM_FULLPATH))

--- a/scripts/build
+++ b/scripts/build
@@ -146,7 +146,8 @@ SZ=`du -sb $Z_WASM | awk '{print $1}'`
 KB=$(expr $SZ / 1024)
 TMSP=`date --utc +%FT%TZ`
 SHA256=0x`shasum -a 256 $Z_WASM | awk '{print $1}'`
-PROP=`subwasm -j info $Z_WASM | jq -r .proposal_hash`
+SET_CODE_PROP=`subwasm -j info $Z_WASM | jq -r .proposal_hash`
+AUTHORIZE_UPGRADE_PROP=`subwasm -j info $Z_WASM | jq -r .parachain_authorize_upgrade_hash`
 MULTIHASH=`subwasm -j info $Z_WASM | jq -r .ipfs_hash`
 
 # If we work on a snapshot, we will NOT get a .git folder to work on
@@ -178,7 +179,8 @@ JSON=$( jq -n \
     --arg bytes "$SZ" \
     --arg wasm "$WASM" \
     --arg z_wasm "$Z_WASM" \
-    --arg prop "$PROP" \
+    --arg set_code_prop "$SET_CODE_PROP" \
+    --arg authorize_upgrade_prop "$AUTHORIZE_UPGRADE_PROP" \
     --arg sha256 "$SHA256" \
     --arg tmsp "$TMSP" \
     --arg git_tag "$GIT_TAG" \
@@ -201,7 +203,8 @@ JSON=$( jq -n \
         pkg: $pkg,
         tmsp: $tmsp,
         size: $bytes,
-        prop: $prop,
+        set_code_prop: $set_code_prop,
+        authorize_upgrade_prop: $authorize_upgrade_prop,
         ipfs: $ipfs,
         sha256: $sha256,
         wasm: $z_wasm,

--- a/scripts/build
+++ b/scripts/build
@@ -146,7 +146,7 @@ SZ=`du -sb $Z_WASM | awk '{print $1}'`
 KB=$(expr $SZ / 1024)
 TMSP=`date --utc +%FT%TZ`
 SHA256=0x`shasum -a 256 $Z_WASM | awk '{print $1}'`
-SET_CODE_PROP=`subwasm -j info $Z_WASM | jq -r .proposal_hash`
+PROP=`subwasm -j info $Z_WASM | jq -r .proposal_hash`
 AUTHORIZE_UPGRADE_PROP=`subwasm -j info $Z_WASM | jq -r .parachain_authorize_upgrade_hash`
 MULTIHASH=`subwasm -j info $Z_WASM | jq -r .ipfs_hash`
 
@@ -179,7 +179,7 @@ JSON=$( jq -n \
     --arg bytes "$SZ" \
     --arg wasm "$WASM" \
     --arg z_wasm "$Z_WASM" \
-    --arg set_code_prop "$SET_CODE_PROP" \
+    --arg prop "$PROP" \
     --arg authorize_upgrade_prop "$AUTHORIZE_UPGRADE_PROP" \
     --arg sha256 "$SHA256" \
     --arg tmsp "$TMSP" \
@@ -203,7 +203,7 @@ JSON=$( jq -n \
         pkg: $pkg,
         tmsp: $tmsp,
         size: $bytes,
-        set_code_prop: $set_code_prop,
+        prop: $prop,
         authorize_upgrade_prop: $authorize_upgrade_prop,
         ipfs: $ipfs,
         sha256: $sha256,

--- a/templates/output.txt
+++ b/templates/output.txt
@@ -11,27 +11,27 @@ Summary generated with {{ gen }} using the docker image {{ context.docker.image 
  Time        : {{ tmsp }}
 
 == Compact
- Version                                      : {{ runtimes.compact.subwasm.core_version }}
- Metadata                                     : V{{ runtimes.compact.subwasm.metadata_version }}
- Size                                         : {{ runtimes.compact.size | int | filesizeformat }} ({{ runtimes.compact.size }} bytes)
- system.setCode proposal                      : {{ runtimes.compact.set_code_prop }}
- parachainSystem.authorizeUpgrade proposal    : {{ runtimes.compact.authorize_upgrade_prop }}
- IPFS                                         : {{ runtimes.compact.ipfs }}
- BLAKE2_256                                   : {{ runtimes.compact.blake2_256 }}
- Wasm                                         : {{ runtimes.compact.wasm }}
+ Version                    : {{ runtimes.compact.subwasm.core_version }}
+ Metadata                   : V{{ runtimes.compact.subwasm.metadata_version }}
+ Size                       : {{ runtimes.compact.size | int | filesizeformat }} ({{ runtimes.compact.size }} bytes)
+ setCode proposal           : {{ runtimes.compact.set_code_prop }}
+ authorizeUpgrade proposal  : {{ runtimes.compact.authorize_upgrade_prop }}
+ IPFS                       : {{ runtimes.compact.ipfs }}
+ BLAKE2_256                 : {{ runtimes.compact.blake2_256 }}
+ Wasm                       : {{ runtimes.compact.wasm }}
 
 == Compressed
 {%- if  runtimes.compressed %}
 {%- set ratio = 100 - (( runtimes.compressed.subwasm.compression.size_compressed / runtimes.compressed.subwasm.compression.size_decompressed) ) * 100 %}
- Version                                      : {{ runtimes.compressed.subwasm.core_version }}
- Metadata                                     : V{{ runtimes.compressed.subwasm.metadata_version }}
- Size                                         : {{ runtimes.compressed.size | int | filesizeformat }} ({{ runtimes.compressed.size }} bytes)
- Compression                                  : {{ ratio | round(method="ceil", precision=2) }}%
- system.setCode proposal                      : {{ runtimes.compressed.set_code_prop }}
- parachainSystem.authorizeUpgrade proposal    : {{ runtimes.compressed.authorize_upgrade_prop }}
- IPFS                                         : {{ runtimes.compressed.ipfs }}
- BLAKE2_256                                   : {{ runtimes.compressed.blake2_256 }}
- Wasm                                         : {{ runtimes.compressed.wasm }}
+ Version                    : {{ runtimes.compressed.subwasm.core_version }}
+ Metadata                   : V{{ runtimes.compressed.subwasm.metadata_version }}
+ Size                       : {{ runtimes.compressed.size | int | filesizeformat }} ({{ runtimes.compressed.size }} bytes)
+ Compression                : {{ ratio | round(method="ceil", precision=2) }}%
+ setCode proposal           : {{ runtimes.compressed.set_code_prop }}
+ authorizeUpgrade proposal  : {{ runtimes.compressed.authorize_upgrade_prop }}
+ IPFS                       : {{ runtimes.compressed.ipfs }}
+ BLAKE2_256                 : {{ runtimes.compressed.blake2_256 }}
+ Wasm                       : {{ runtimes.compressed.wasm }}
 {% else  %}
  No compressed runtime found
 {% endif %}

--- a/templates/output.txt
+++ b/templates/output.txt
@@ -11,27 +11,27 @@ Summary generated with {{ gen }} using the docker image {{ context.docker.image 
  Time        : {{ tmsp }}
 
 == Compact
- Version                    : {{ runtimes.compact.subwasm.core_version }}
- Metadata                   : V{{ runtimes.compact.subwasm.metadata_version }}
- Size                       : {{ runtimes.compact.size | int | filesizeformat }} ({{ runtimes.compact.size }} bytes)
- setCode proposal           : {{ runtimes.compact.set_code_prop }}
- authorizeUpgrade proposal  : {{ runtimes.compact.authorize_upgrade_prop }}
- IPFS                       : {{ runtimes.compact.ipfs }}
- BLAKE2_256                 : {{ runtimes.compact.blake2_256 }}
- Wasm                       : {{ runtimes.compact.wasm }}
+ Version          : {{ runtimes.compact.subwasm.core_version }}
+ Metadata         : V{{ runtimes.compact.subwasm.metadata_version }}
+ Size             : {{ runtimes.compact.size | int | filesizeformat }} ({{ runtimes.compact.size }} bytes)
+ setCode          : {{ runtimes.compact.set_code_prop }}
+ authorizeUpgrade : {{ runtimes.compact.authorize_upgrade_prop }}
+ IPFS             : {{ runtimes.compact.ipfs }}
+ BLAKE2_256       : {{ runtimes.compact.blake2_256 }}
+ Wasm             : {{ runtimes.compact.wasm }}
 
 == Compressed
 {%- if  runtimes.compressed %}
 {%- set ratio = 100 - (( runtimes.compressed.subwasm.compression.size_compressed / runtimes.compressed.subwasm.compression.size_decompressed) ) * 100 %}
- Version                    : {{ runtimes.compressed.subwasm.core_version }}
- Metadata                   : V{{ runtimes.compressed.subwasm.metadata_version }}
- Size                       : {{ runtimes.compressed.size | int | filesizeformat }} ({{ runtimes.compressed.size }} bytes)
- Compression                : {{ ratio | round(method="ceil", precision=2) }}%
- setCode proposal           : {{ runtimes.compressed.set_code_prop }}
- authorizeUpgrade proposal  : {{ runtimes.compressed.authorize_upgrade_prop }}
- IPFS                       : {{ runtimes.compressed.ipfs }}
- BLAKE2_256                 : {{ runtimes.compressed.blake2_256 }}
- Wasm                       : {{ runtimes.compressed.wasm }}
+ Version          : {{ runtimes.compressed.subwasm.core_version }}
+ Metadata         : V{{ runtimes.compressed.subwasm.metadata_version }}
+ Size             : {{ runtimes.compressed.size | int | filesizeformat }} ({{ runtimes.compressed.size }} bytes)
+ Compression      : {{ ratio | round(method="ceil", precision=2) }}%
+ setCode          : {{ runtimes.compressed.set_code_prop }}
+ authorizeUpgrade : {{ runtimes.compressed.authorize_upgrade_prop }}
+ IPFS             : {{ runtimes.compressed.ipfs }}
+ BLAKE2_256       : {{ runtimes.compressed.blake2_256 }}
+ Wasm             : {{ runtimes.compressed.wasm }}
 {% else  %}
  No compressed runtime found
 {% endif %}

--- a/templates/output.txt
+++ b/templates/output.txt
@@ -11,25 +11,27 @@ Summary generated with {{ gen }} using the docker image {{ context.docker.image 
  Time        : {{ tmsp }}
 
 == Compact
- Version     : {{ runtimes.compact.subwasm.core_version }}
- Metadata    : V{{ runtimes.compact.subwasm.metadata_version }}
- Size        : {{ runtimes.compact.size | int | filesizeformat }} ({{ runtimes.compact.size }} bytes)
- Proposal    : {{ runtimes.compact.prop }}
- IPFS        : {{ runtimes.compact.ipfs }}
- BLAKE2_256  : {{ runtimes.compact.blake2_256 }}
- Wasm        : {{ runtimes.compact.wasm }}
+ Version                                      : {{ runtimes.compact.subwasm.core_version }}
+ Metadata                                     : V{{ runtimes.compact.subwasm.metadata_version }}
+ Size                                         : {{ runtimes.compact.size | int | filesizeformat }} ({{ runtimes.compact.size }} bytes)
+ system.setCode proposal                      : {{ runtimes.compact.set_code_prop }}
+ parachainSystem.authorizeUpgrade proposal    : {{ runtimes.compact.authorize_upgrade_prop }}
+ IPFS                                         : {{ runtimes.compact.ipfs }}
+ BLAKE2_256                                   : {{ runtimes.compact.blake2_256 }}
+ Wasm                                         : {{ runtimes.compact.wasm }}
 
 == Compressed
 {%- if  runtimes.compressed %}
 {%- set ratio = 100 - (( runtimes.compressed.subwasm.compression.size_compressed / runtimes.compressed.subwasm.compression.size_decompressed) ) * 100 %}
- Version     : {{ runtimes.compressed.subwasm.core_version }}
- Metadata    : V{{ runtimes.compressed.subwasm.metadata_version }}
- Size        : {{ runtimes.compressed.size | int | filesizeformat }} ({{ runtimes.compressed.size }} bytes)
- Compression : {{ ratio | round(method="ceil", precision=2) }}%
- Proposal    : {{ runtimes.compressed.prop }}
- IPFS        : {{ runtimes.compressed.ipfs }}
- BLAKE2_256  : {{ runtimes.compressed.blake2_256 }}
- Wasm        : {{ runtimes.compressed.wasm }}
+ Version                                      : {{ runtimes.compressed.subwasm.core_version }}
+ Metadata                                     : V{{ runtimes.compressed.subwasm.metadata_version }}
+ Size                                         : {{ runtimes.compressed.size | int | filesizeformat }} ({{ runtimes.compressed.size }} bytes)
+ Compression                                  : {{ ratio | round(method="ceil", precision=2) }}%
+ system.setCode proposal                      : {{ runtimes.compressed.set_code_prop }}
+ parachainSystem.authorizeUpgrade proposal    : {{ runtimes.compressed.authorize_upgrade_prop }}
+ IPFS                                         : {{ runtimes.compressed.ipfs }}
+ BLAKE2_256                                   : {{ runtimes.compressed.blake2_256 }}
+ Wasm                                         : {{ runtimes.compressed.wasm }}
 {% else  %}
  No compressed runtime found
 {% endif %}


### PR DESCRIPTION
As the title implies, adds the information about the call that parachains should execute for a runtime upgrade.