### PR TITLE
Remove set-output

### DIFF
--- a/.github/workflows/manual-acala.yml
+++ b/.github/workflows/manual-acala.yml
@@ -25,7 +25,7 @@ jobs:
         chain: ["karura"]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
         with:
           repository: AcalaNetwork/Acala
           ref: ${{ github.event.inputs.ref }}
@@ -34,7 +34,7 @@ jobs:
 
       - name: Srtool build
         id: srtool_build
-        uses: chevdor/srtool-actions@v0.3.0
+        uses: chevdor/srtool-actions@v0.6.0
         with:
           chain: ${{ matrix.chain }}
           tag: ${{ github.event.inputs.srtool_tag }}
@@ -47,7 +47,7 @@ jobs:
 
       # it takes a while to build the runtime, so let's save the artifact as soon as we have it
       - name: Archive Artifacts for ${{ matrix.chain }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
         with:
           name: ${{ matrix.chain }}-runtime
           path: |
@@ -76,7 +76,7 @@ jobs:
           subwasm diff ${{ steps.srtool_build.outputs.wasm }} --chain-b ${{ matrix.chain }} | tee ${{ matrix.chain }}-diff.txt
 
       - name: Archive Subwasm results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
         with:
           name: ${{ matrix.chain }}-runtime
           path: |

--- a/.github/workflows/manual-cumulus.yml
+++ b/.github/workflows/manual-cumulus.yml
@@ -32,7 +32,7 @@ jobs:
             runtime: shell
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
         with:
           repository: paritytech/cumulus
           ref: ${{ github.event.inputs.ref }}
@@ -40,7 +40,7 @@ jobs:
 
       - name: Srtool build
         id: srtool_build
-        uses: chevdor/srtool-actions@v0.4.0
+        uses: chevdor/srtool-actions@v0.6.0
         with:
           chain: ${{ matrix.runtime }}
           tag: ${{ github.event.inputs.srtool_tag }}
@@ -54,7 +54,7 @@ jobs:
 
       # it takes a while to build the runtime, so let's save the artifact as soon as we have it
       - name: Archive Artifacts for ${{ matrix.runtime }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
         with:
           name: ${{ matrix.runtime }}-runtime
           path: |
@@ -83,7 +83,7 @@ jobs:
           subwasm diff ${{ steps.srtool_build.outputs.wasm }} --chain-b ${{ matrix.runtime }} | tee ${{ matrix.runtime }}-diff.txt
 
       - name: Archive Subwasm results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
         with:
           name: ${{ matrix.runtime }}-runtime
           path: |

--- a/.github/workflows/manual-moonbeam.yml
+++ b/.github/workflows/manual-moonbeam.yml
@@ -25,7 +25,7 @@ jobs:
         chain: ["moonriver"]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
         with:
           repository: PureStake/moonbeam
           ref: ${{ github.event.inputs.ref }}
@@ -33,7 +33,7 @@ jobs:
 
       - name: Srtool build
         id: srtool_build
-        uses: chevdor/srtool-actions@v0.3.0
+        uses: chevdor/srtool-actions@v0.6.0
         with:
           chain: ${{ matrix.chain }}
           tag: ${{ github.event.inputs.srtool_tag }}
@@ -46,7 +46,7 @@ jobs:
 
       # it takes a while to build the runtime, so let's save the artifact as soon as we have it
       - name: Archive Artifacts for ${{ matrix.chain }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
         with:
           name: ${{ matrix.chain }}-runtime
           path: |
@@ -76,7 +76,7 @@ jobs:
           echo "No live chain to compare" > ${{ matrix.chain }}-diff.txt
 
       - name: Archive Subwasm results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
         with:
           name: ${{ matrix.chain }}-runtime
           path: |

--- a/.github/workflows/manual-polkadot.yml
+++ b/.github/workflows/manual-polkadot.yml
@@ -26,7 +26,7 @@ jobs:
         chain: ["polkadot", "kusama", "westend"]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
         with:
           repository: paritytech/polkadot
           ref: ${{ github.event.inputs.ref }}
@@ -34,7 +34,7 @@ jobs:
 
       - name: Srtool build
         id: srtool_build
-        uses: chevdor/srtool-actions@v0.3.0
+        uses: chevdor/srtool-actions@v0.6.0
         with:
           chain: ${{ matrix.chain }}
           tag: ${{ github.event.inputs.srtool_tag }}
@@ -47,7 +47,7 @@ jobs:
 
       # it takes a while to build the runtime, so let's save the artifact as soon as we have it
       - name: Archive Artifacts for ${{ matrix.chain }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
         with:
           name: ${{ matrix.chain }}-runtime
           path: |
@@ -76,7 +76,7 @@ jobs:
           subwasm diff ${{ steps.srtool_build.outputs.wasm }} --chain-b ${{ matrix.chain }} | tee ${{ matrix.chain }}-diff.txt
 
       - name: Archive Subwasm results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
         with:
           name: ${{ matrix.chain }}-runtime
           path: |

--- a/.github/workflows/manual-shiden.yml
+++ b/.github/workflows/manual-shiden.yml
@@ -25,7 +25,7 @@ jobs:
         chain: ["shiden"]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
         with:
           repository: AstarNetwork/Astar
           ref: ${{ github.event.inputs.ref }}
@@ -34,7 +34,7 @@ jobs:
 
       - name: Srtool build
         id: srtool_build
-        uses: chevdor/srtool-actions@v0.3.0
+        uses: chevdor/srtool-actions@v0.6.0
         with:
           chain: ${{ matrix.chain }}
           tag: ${{ github.event.inputs.srtool_tag }}
@@ -47,7 +47,7 @@ jobs:
 
       # it takes a while to build the runtime, so let's save the artifact as soon as we have it
       - name: Archive Artifacts for ${{ matrix.chain }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
         with:
           name: ${{ matrix.chain }}-runtime
           path: |
@@ -77,7 +77,7 @@ jobs:
           echo "No live chain to compare" > ${{ matrix.chain }}-diff.txt
 
       - name: Archive Subwasm results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
         with:
           name: ${{ matrix.chain }}-runtime
           path: |

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -39,7 +39,7 @@ jobs:
     name: Build ${{ github.event.inputs.repository }}/${{ github.event.inputs.package }} ${{ github.event.inputs.ref }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
         with:
           repository: ${{ github.event.inputs.repository }}
           ref: ${{ github.event.inputs.ref }}
@@ -47,7 +47,7 @@ jobs:
 
       - name: Srtool build
         id: srtool_build
-        uses: chevdor/srtool-actions@v0.3.0
+        uses: chevdor/srtool-actions@v0.6.0
         with:
           chain: ${{ github.event.inputs.chain }}
           package: ${{ github.event.inputs.package }}
@@ -63,7 +63,7 @@ jobs:
 
       # it takes a while to build the runtime, so let's save the artifact as soon as we have it
       - name: Archive Artifacts for ${{ github.event.inputs.chain }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
         with:
           name: ${{ github.event.inputs.chain }}-runtime
           path: |
@@ -92,7 +92,7 @@ jobs:
           subwasm diff ${{ steps.srtool_build.outputs.wasm }} --chain-b ${{ github.event.inputs.chain }} | tee ${{ github.event.inputs.chain }}-diff.txt
 
       - name: Archive Subwasm results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
         with:
           name: ${{ github.event.inputs.chain }}-runtime
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
       - name: Build image
         run: |
@@ -25,7 +25,7 @@ jobs:
           docker save srtool | gzip > srtool.tar.gz
 
       - name: Cache the image
-        uses: actions/cache@v2
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # v3.0.11
         with:
           key: srtool-docker-image-${{ github.sha }}
           path: |
@@ -39,7 +39,7 @@ jobs:
       release_url: ${{ steps.create-release.outputs.html_url }}
       asset_upload_url: ${{ steps.create-release.outputs.upload_url }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
         with:
           fetch-depth: 0
       - name: Get Release Version
@@ -52,7 +52,7 @@ jobs:
           echo "SRTOOL_VERSION=$SRTOOL_VERSION" >> $GITHUB_ENV
           echo "RUSTC_VERSION=$RUSTC_VERSION" >> $GITHUB_ENV
       - name: Cache the image
-        uses: actions/cache@v2
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # v3.0.11
         with:
           key: srtool-docker-image-${{ github.sha }}
           path: |
@@ -85,7 +85,7 @@ jobs:
 
       - name: Create Release
         id: create-release
-        uses: actions/create-release@v1
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1.1.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -99,7 +99,7 @@ jobs:
     needs: ["create_draft"]
     steps:
       - name: Cache the image
-        uses: actions/cache@v2
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # v3.0.11
         with:
           key: srtool-docker-image-${{ github.sha }}
           path: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -39,7 +39,7 @@ jobs:
           docker save srtool | gzip > srtool.tar.gz
 
       - name: Cache the image
-        uses: actions/cache@v2
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # v3.0.11
         with:
           key: srtool-docker-image-${{ github.sha }}
           path: |
@@ -51,7 +51,7 @@ jobs:
     continue-on-error: false
     steps:
       - name: Cache the image
-        uses: actions/cache@v2
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # v3.0.11
         with:
           key: srtool-docker-image-${{ github.sha }}
           path: |
@@ -81,7 +81,7 @@ jobs:
     needs: build
     continue-on-error: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -90,7 +90,7 @@ jobs:
           ls -al
 
       - name: Cache the image
-        uses: actions/cache@v2
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # v3.0.11
         with:
           key: srtool-docker-image-${{ github.sha }}
           path: |
@@ -129,7 +129,7 @@ jobs:
         chain: ["polkadot", "kusama", "westend"]
     steps:
       - name: Cache the image
-        uses: actions/cache@v2
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # v3.0.11
         with:
           key: srtool-docker-image-${{ github.sha }}
           path: |
@@ -141,7 +141,7 @@ jobs:
           docker images --digests
 
       - name: Check out the Polkadot repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
         with:
           repository: paritytech/polkadot
           ref: ${{ github.event.inputs.ref }}
@@ -219,7 +219,7 @@ jobs:
           echo "Compressed Runtime: ${{ steps.srtool_build.outputs.wasm_compressed }}"
 
       - name: Archive Artifacts for ${{ matrix.chain }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
         env:
           RUNTIME_DIR: runtime/${{ matrix.chain }}
         with:
@@ -245,7 +245,7 @@ jobs:
             runtime: shell
     steps:
       - name: Cache the image
-        uses: actions/cache@v2
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # v3.0.11
         with:
           key: srtool-docker-image-${{ github.sha }}
           path: |
@@ -257,7 +257,7 @@ jobs:
           docker images --digests
 
       - name: Check out the Cumulus repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
         with:
           repository: paritytech/cumulus
           ref: ${{ github.event.inputs.ref }}
@@ -322,7 +322,7 @@ jobs:
           echo "Compressed Runtime: ${{ steps.srtool_build.outputs.wasm_compressed }}"
 
       - name: Archive Artifacts for ${{ matrix.runtime }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
         env:
           RUNTIME_DIR: parachains/runtimes/${{ matrix.category }}/${{ matrix.runtime }}
         with:
@@ -342,7 +342,7 @@ jobs:
         chain: ["millau", "rialto"]
     steps:
       - name: Cache the image
-        uses: actions/cache@v2
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # v3.0.11
         with:
           key: srtool-docker-image-${{ github.sha }}
           path: |
@@ -354,7 +354,7 @@ jobs:
           docker images --digests
 
       - name: Check out the Bridges repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
         with:
           repository: paritytech/parity-bridges-common
           ref: ${{ github.event.inputs.ref }}
@@ -419,7 +419,7 @@ jobs:
           echo "Compressed Runtime: ${{ steps.srtool_build.outputs.wasm_compressed }}"
 
       - name: Archive Artifacts for ${{ matrix.chain }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
         env:
           RUNTIME_DIR: bin/${{ matrix.chain }}/runtime
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -200,16 +200,16 @@ jobs:
               JSON="$line"
             done
 
-            echo ::set-output name=json::$JSON
+            echo "json=$JSON" >> $GITHUB_OUTPUT
             echo "JSON=$JSON" >> $GITHUB_ENV
 
             echo $JSON | jq .
 
             WASM=`echo $JSON | jq -r .runtimes.compact.wasm`
-            echo ::set-output name=wasm::$WASM
+            echo "wasm=$WASM" >> $GITHUB_OUTPUT
 
             Z_WASM=`echo $JSON | jq -r .runtimes.compressed.wasm`
-            echo ::set-output name=wasm_compressed::$Z_WASM
+            echo "wasm_compressed=$Z_WASM" >> $GITHUB_OUTPUT
           }
 
       - name: Summary for ${{ matrix.chain }}
@@ -303,16 +303,16 @@ jobs:
               JSON="$line"
             done
 
-            echo ::set-output name=json::$JSON
+            echo "json=$JSON" >> $GITHUB_OUTPUT
             echo "JSON=$JSON" >> $GITHUB_ENV
 
             echo $JSON | jq .
 
             WASM=`echo $JSON | jq -r .runtimes.compact.wasm`
-            echo ::set-output name=wasm::$WASM
+            echo "wasm=$WASM" >> $GITHUB_OUTPUT
 
             Z_WASM=`echo $JSON | jq -r .runtimes.compressed.wasm`
-            echo ::set-output name=wasm_compressed::$Z_WASM
+            echo "wasm_compressed=$Z_WASM" >> $GITHUB_OUTPUT
           }
 
       - name: Summary for ${{ matrix.runtime }}
@@ -400,16 +400,16 @@ jobs:
               JSON="$line"
             done
 
-            echo ::set-output name=json::$JSON
+            echo "json=$JSON" >> $GITHUB_OUTPUT
             echo "JSON=$JSON" >> $GITHUB_ENV
 
             echo $JSON | jq .
 
             WASM=`echo $JSON | jq -r .runtimes.compact.wasm`
-            echo ::set-output name=wasm::$WASM
+            echo "wasm=$WASM" >> $GITHUB_OUTPUT
 
             Z_WASM=`echo $JSON | jq -r .runtimes.compressed.wasm`
-            echo ::set-output name=wasm_compressed::$Z_WASM
+            echo "wasm_compressed=$Z_WASM" >> $GITHUB_OUTPUT
           }
 
       - name: Summary for ${{ matrix.chain }}


### PR DESCRIPTION
GH is deprecating `set-output`. This PR updates the previous usages to the new practises.

⚠️ This PR should only be merged after https://github.com/chevdor/srtool-actions/pull/15 and once the `chevdor/srtool-actions@v0.6.0` tag has been created.