### PR TITLE
chore: update subwasm dependency to 0.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,8 @@ RUN apt update && \
     apt upgrade -y && \
     apt install --no-install-recommends -y \
     cmake pkg-config libssl-dev make protobuf-compiler \
-    git clang bsdmainutils ca-certificates curl && \
-    curl -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 --output /usr/bin/jq && chmod a+x /usr/bin/jq && \
+        git clang bsdmainutils ca-certificates curl && \
+        curl -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 --output /usr/bin/jq && chmod a+x /usr/bin/jq && \
     rm -rf /var/lib/apt/lists/* /tmp/* && apt clean
 
 RUN curl -L https://github.com/chevdor/subwasm/releases/download/v${SUBWASM_VERSION}/subwasm_linux_amd64_v${SUBWASM_VERSION}.deb --output subwasm.deb && dpkg -i subwasm.deb && subwasm --version && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ COPY ./templates ${SRTOOL_TEMPLATES}/
 RUN apt update && \
     apt upgrade -y && \
     apt install --no-install-recommends -y \
-    cmake pkg-config libssl-dev make protobuf-compiler \
+        cmake pkg-config libssl-dev make protobuf-compiler \
         git clang bsdmainutils ca-certificates curl && \
     curl -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 --output /usr/bin/jq && chmod a+x /usr/bin/jq && \
     rm -rf /var/lib/apt/lists/* /tmp/* && apt clean

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ WORKDIR /tmp
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Tooling
-ARG SUBWASM_VERSION=0.18.0
+ARG SUBWASM_VERSION=0.19.0
 ARG TERA_CLI_VERSION=0.2.2
 ARG TOML_CLI_VERSION=0.2.2
 
@@ -32,8 +32,8 @@ COPY ./templates ${SRTOOL_TEMPLATES}/
 RUN apt update && \
     apt upgrade -y && \
     apt install --no-install-recommends -y \
-        cmake pkg-config libssl-dev make protobuf-compiler \
-        git clang bsdmainutils ca-certificates curl && \
+    cmake pkg-config libssl-dev make protobuf-compiler \
+    git clang bsdmainutils ca-certificates curl && \
     curl -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 --output /usr/bin/jq && chmod a+x /usr/bin/jq && \
     rm -rf /var/lib/apt/lists/* /tmp/* && apt clean
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN apt update && \
     apt install --no-install-recommends -y \
     cmake pkg-config libssl-dev make protobuf-compiler \
         git clang bsdmainutils ca-certificates curl && \
-        curl -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 --output /usr/bin/jq && chmod a+x /usr/bin/jq && \
+    curl -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 --output /usr/bin/jq && chmod a+x /usr/bin/jq && \
     rm -rf /var/lib/apt/lists/* /tmp/* && apt clean
 
 RUN curl -L https://github.com/chevdor/subwasm/releases/download/v${SUBWASM_VERSION}/subwasm_linux_amd64_v${SUBWASM_VERSION}.deb --output subwasm.deb && dpkg -i subwasm.deb && subwasm --version && \


### PR DESCRIPTION
Since the new subwasm version includes a [feature](https://github.com/chevdor/subwasm/pull/61) we need, this PR bumps the subwasm dependency to the newly released version 0.19 which includes this feature.