### PR TITLE
Switch to monorepo

### DIFF
--- a/.github/workflows/manual-acala.yml
+++ b/.github/workflows/manual-acala.yml
@@ -25,7 +25,7 @@ jobs:
         chain: ["karura"]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
         with:
           repository: AcalaNetwork/Acala
           ref: ${{ github.event.inputs.ref }}
@@ -34,7 +34,7 @@ jobs:
 
       - name: Srtool build
         id: srtool_build
-        uses: chevdor/srtool-actions@v0.7.0
+        uses: chevdor/srtool-actions@v0.8.0
         with:
           chain: ${{ matrix.chain }}
           tag: ${{ github.event.inputs.srtool_tag }}

--- a/.github/workflows/manual-cumulus.yml
+++ b/.github/workflows/manual-cumulus.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Srtool build
         id: srtool_build
-        uses: chevdor/srtool-actions@v0.7.0
+        uses: chevdor/srtool-actions@v0.8.0
         with:
           chain: ${{ matrix.runtime }}
           tag: ${{ github.event.inputs.srtool_tag }}

--- a/.github/workflows/manual-cumulus.yml
+++ b/.github/workflows/manual-cumulus.yml
@@ -32,9 +32,9 @@ jobs:
             runtime: shell
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
         with:
-          repository: paritytech/cumulus
+          repository: paritytech/polkadot-sdk
           ref: ${{ github.event.inputs.ref }}
           fetch-depth: 0
 
@@ -44,7 +44,7 @@ jobs:
         with:
           chain: ${{ matrix.runtime }}
           tag: ${{ github.event.inputs.srtool_tag }}
-          runtime_dir: parachains/runtimes/${{ matrix.category }}/${{ matrix.runtime }}
+          runtime_dir: cumulus/parachains/runtimes/${{ matrix.category }}/${{ matrix.runtime }}
 
       - name: Summary
         run: |

--- a/.github/workflows/manual-fellow-runtimes.yml
+++ b/.github/workflows/manual-fellow-runtimes.yml
@@ -1,4 +1,4 @@
-name: Manual Build - Polkadot
+name: Runtimes Fellowship
 
 env:
   SUBWASM_VERSION: 0.20.0
@@ -15,7 +15,7 @@ on:
         default: master
         required: false
   schedule:
-    - cron: "00 03 * * 1" # 3AM weekly on mondays
+    - cron: "00 04 * * 1"
 
 jobs:
   build:
@@ -23,12 +23,41 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        chain: ["polkadot", "kusama", "westend"]
+        include:
+          # Relay
+          - runtime_dir: relay/kusama
+            runtime: kusama-runtime
+            chain: kusama
+          - runtime_dir: relay/polkadot
+            runtime: polkadot-runtime
+            chain: polkadot
+
+          # System parachains / Asset Hub
+          - runtime_dir: system-parachains/asset-hubs/asset-hub-kusama
+            runtime: asset-hub-kusama-runtime
+            chain: asset-hub-kusama
+          - runtime_dir: system-parachains/asset-hubs/asset-hub-polkadot
+            runtime: asset-hub-polkadot-runtime
+            chain: asset-hub-polkadot
+
+          # System parachains / Bridge Hub
+          - runtime_dir: system-parachains/bridge-hubs/bridge-hub-kusama
+            runtime: bridge-hub-kusama-runtime
+            chain: bridge-hub-kusama
+          - runtime_dir: system-parachains/bridge-hubs/bridge-hub-polkadot
+            runtime: bridge-hub-polkadot-runtime
+            chain: bridge-hub-polkadot
+
+          # System parachains / Collectives
+          - runtime_dir: system-parachains/collectives/collectives/polkadot
+            runtime: collectives-polkadot-runtime
+            chain: collectives-polkadot
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
         with:
-          repository: paritytech/polkadot-sdk
+          repository: polkadot-fellows/runtimes
           ref: ${{ github.event.inputs.ref }}
           fetch-depth: 0
 
@@ -38,6 +67,7 @@ jobs:
         with:
           chain: ${{ matrix.chain }}
           tag: ${{ github.event.inputs.srtool_tag }}
+          runtime_dir:  ${{ matrix.runtime_dir }}
 
       - name: Summary
         run: |

--- a/.github/workflows/manual-fellow-runtimes.yml
+++ b/.github/workflows/manual-fellow-runtimes.yml
@@ -12,7 +12,7 @@ on:
         required: false
       ref:
         description: The ref to be used for the repo
-        default: master
+        default: main
         required: false
   schedule:
     - cron: "00 04 * * 1"

--- a/.github/workflows/manual-fellow-runtimes.yml
+++ b/.github/workflows/manual-fellow-runtimes.yml
@@ -49,7 +49,7 @@ jobs:
             chain: bridge-hub-polkadot
 
           # System parachains / Collectives
-          - runtime_dir: system-parachains/collectives/collectives/polkadot
+          - runtime_dir: system-parachains/collectives/collectives-polkadot
             runtime: collectives-polkadot-runtime
             chain: collectives-polkadot
 

--- a/.github/workflows/manual-moonbeam.yml
+++ b/.github/workflows/manual-moonbeam.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Srtool build
         id: srtool_build
-        uses: chevdor/srtool-actions@v0.7.0
+        uses: chevdor/srtool-actions@v0.8.0
         with:
           chain: ${{ matrix.chain }}
           tag: ${{ github.event.inputs.srtool_tag }}

--- a/.github/workflows/manual-moonbeam.yml
+++ b/.github/workflows/manual-moonbeam.yml
@@ -25,7 +25,7 @@ jobs:
         chain: ["moonriver"]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
         with:
           repository: PureStake/moonbeam
           ref: ${{ github.event.inputs.ref }}

--- a/.github/workflows/manual-polkadot.yml
+++ b/.github/workflows/manual-polkadot.yml
@@ -26,9 +26,9 @@ jobs:
         chain: ["polkadot", "kusama", "westend"]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
         with:
-          repository: paritytech/polkadot
+          repository: paritytech/polkadot-sdk
           ref: ${{ github.event.inputs.ref }}
           fetch-depth: 0
 

--- a/.github/workflows/manual-shiden.yml
+++ b/.github/workflows/manual-shiden.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Srtool build
         id: srtool_build
-        uses: chevdor/srtool-actions@v0.7.0
+        uses: chevdor/srtool-actions@v0.8.0
         with:
           chain: ${{ matrix.chain }}
           tag: ${{ github.event.inputs.srtool_tag }}

--- a/.github/workflows/manual-shiden.yml
+++ b/.github/workflows/manual-shiden.yml
@@ -25,7 +25,7 @@ jobs:
         chain: ["shiden"]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
         with:
           repository: AstarNetwork/Astar
           ref: ${{ github.event.inputs.ref }}

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Srtool build
         id: srtool_build
-        uses: chevdor/srtool-actions@v0.7.0
+        uses: chevdor/srtool-actions@v0.8.0
         with:
           chain: ${{ github.event.inputs.chain }}
           package: ${{ github.event.inputs.package }}

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -16,19 +16,19 @@ on:
         required: false
       chain:
         description: The chain to use
-        default: node-template
+        default: westend-runtime
         required: false
       package:
         description: The package to be used
-        default: node-template-runtime
+        default: westend-runtime
         required: true
       repository:
         description: The repository to be used
-        default: paritytech/substrate
+        default: paritytech/polkadot-sdk
         required: true
       runtime_dir:
         description: The runtime_dir to be used
-        default: bin/node-template/runtime/
+        default: polkadot/runtime/westend
         required: true
       ref:
         description: The ref to be used for the repo
@@ -39,7 +39,7 @@ jobs:
     name: Build ${{ github.event.inputs.repository }}/${{ github.event.inputs.package }} ${{ github.event.inputs.ref }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
         with:
           repository: ${{ github.event.inputs.repository }}
           ref: ${{ github.event.inputs.ref }}

--- a/.github/workflows/quick-test.yml
+++ b/.github/workflows/quick-test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: false
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -78,7 +78,7 @@ jobs:
     needs: build
     continue-on-error: false
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -137,19 +137,19 @@ jobs:
           docker load -i srtool.tar.gz
           docker images --digests
 
-      - name: Check out the Polkadot repo
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+      - name: Check out the Polkadot SDK repo
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
         with:
-          repository: paritytech/polkadot
+          repository: paritytech/polkadot-sdk
           ref: ${{ github.event.inputs.ref }}
           fetch-depth: 0
-          path: polkadot
+          path: sdk
 
       - name: Run srtool info
         env:
           PACKAGE: ${{ matrix.chain }}-runtime
-          RUNTIME_DIR: runtime/${{ matrix.chain }}
-        working-directory: polkadot
+          RUNTIME_DIR: polkadot/runtime/${{ matrix.chain }}
+        working-directory: sdk
         run: |
           INFO=$(docker run --rm -i \
             -e PACKAGE=$PACKAGE \
@@ -167,7 +167,7 @@ jobs:
       - name: Debug information
         env:
           PACKAGE: ${{ matrix.chain }}-runtime
-          RUNTIME_DIR: runtime/${{ matrix.chain }}
+          RUNTIME_DIR: polkadot/runtime/${{ matrix.chain }}
         working-directory: polkadot
         run: |
           echo "::group::Runtimes"
@@ -189,7 +189,7 @@ jobs:
         id: srtool_build
         env:
           PACKAGE: ${{ matrix.chain }}-runtime
-          RUNTIME_DIR: runtime/${{ matrix.chain }}
+          RUNTIME_DIR: polkadot/runtime/${{ matrix.chain }}
         working-directory: polkadot
         run: |
           CMD="docker run --rm -i \

--- a/.github/workflows/quick-test.yml
+++ b/.github/workflows/quick-test.yml
@@ -221,7 +221,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Summary for ${{ matrix.chain }}
-        working-directory: polkadot
+        working-directory: sdk
         run: |
           echo "::group::JSON digest"
           echo $JSON | jq . | tee ${{ matrix.chain }}-srtool-digest.json

--- a/.github/workflows/quick-test.yml
+++ b/.github/workflows/quick-test.yml
@@ -168,7 +168,7 @@ jobs:
         env:
           PACKAGE: ${{ matrix.chain }}-runtime
           RUNTIME_DIR: polkadot/runtime/${{ matrix.chain }}
-        working-directory: polkadot
+        working-directory: sdk
         run: |
           echo "::group::Runtimes"
           ls -al runtime || true
@@ -190,7 +190,7 @@ jobs:
         env:
           PACKAGE: ${{ matrix.chain }}-runtime
           RUNTIME_DIR: polkadot/runtime/${{ matrix.chain }}
-        working-directory: polkadot
+        working-directory: sdk
         run: |
           CMD="docker run --rm -i \
             -e PACKAGE=$PACKAGE \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: false
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
 
       - name: Build image
         run: |
@@ -39,7 +39,7 @@ jobs:
       release_url: ${{ steps.create-release.outputs.html_url }}
       asset_upload_url: ${{ steps.create-release.outputs.upload_url }}
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
         with:
           fetch-depth: 0
       - name: Get Release Version

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: false
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -81,7 +81,7 @@ jobs:
     needs: build
     continue-on-error: false
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -141,18 +141,18 @@ jobs:
           docker images --digests
 
       - name: Check out the Polkadot repo
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
         with:
-          repository: paritytech/polkadot
+          repository: paritytech/polkadot-sdk
           ref: ${{ github.event.inputs.ref }}
           fetch-depth: 0
-          path: polkadot
+          path: sdk
 
       - name: Run srtool info
         env:
           PACKAGE: ${{ matrix.chain }}-runtime
-          RUNTIME_DIR: runtime/${{ matrix.chain }}
-        working-directory: polkadot
+          RUNTIME_DIR: polkadot/runtime/${{ matrix.chain }}
+        working-directory: sdk
         run: |
           INFO=$(docker run --rm -i \
             -e PACKAGE=$PACKAGE \
@@ -170,7 +170,7 @@ jobs:
       - name: Debugging
         env:
           PACKAGE: ${{ matrix.chain }}-runtime
-          RUNTIME_DIR: runtime/${{ matrix.chain }}
+          RUNTIME_DIR: polkadot/runtime/${{ matrix.chain }}
         working-directory: polkadot
         run: |
           ls -al runtime || true
@@ -184,7 +184,7 @@ jobs:
         id: srtool_build
         env:
           PACKAGE: ${{ matrix.chain }}-runtime
-          RUNTIME_DIR: runtime/${{ matrix.chain }}
+          RUNTIME_DIR: polkadot/runtime/${{ matrix.chain }}
         working-directory: polkadot
         run: |
           CMD="docker run --rm -i \
@@ -270,18 +270,18 @@ jobs:
           docker images --digests
 
       - name: Check out the Cumulus repo
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
         with:
-          repository: paritytech/cumulus
+          repository: paritytech/polkadot-sdk
           ref: ${{ github.event.inputs.ref }}
           fetch-depth: 0
-          path: cumulus
+          path: sdk
 
       - name: Run srtool info
         env:
           PACKAGE: ${{ matrix.chain }}-runtime
-          RUNTIME_DIR: parachains/runtimes/${{ matrix.category }}/${{ matrix.chain }}
-        working-directory: cumulus
+          RUNTIME_DIR: cumulus/parachains/runtimes/${{ matrix.category }}/${{ matrix.chain }}
+        working-directory: sdk
         run: |
           INFO=$(docker run --rm -i \
             -e PACKAGE=$PACKAGE \
@@ -300,7 +300,7 @@ jobs:
         id: srtool_build
         env:
           PACKAGE: ${{ matrix.chain }}-runtime
-          RUNTIME_DIR: parachains/runtimes/${{ matrix.category }}/${{ matrix.chain }}
+          RUNTIME_DIR: cumulus/parachains/runtimes/${{ matrix.category }}/${{ matrix.chain }}
         working-directory: cumulus
         run: |
           CMD="docker run --rm -i \
@@ -380,7 +380,7 @@ jobs:
           docker images --digests
 
       - name: Check out the Bridges repo
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
         with:
           repository: paritytech/parity-bridges-common
           ref: ${{ github.event.inputs.ref }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -216,7 +216,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Summary for ${{ matrix.chain }}
-        working-directory: polkadot
+        working-directory: sdk
         run: |
           echo "::group::JSON digest"
           echo $JSON | jq . | tee ${{ matrix.chain }}-srtool-digest.json
@@ -301,7 +301,7 @@ jobs:
         env:
           PACKAGE: ${{ matrix.chain }}-runtime
           RUNTIME_DIR: cumulus/parachains/runtimes/${{ matrix.category }}/${{ matrix.chain }}
-        working-directory: cumulus
+        working-directory: sdk
         run: |
           CMD="docker run --rm -i \
             -e PACKAGE=$PACKAGE \
@@ -332,7 +332,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Summary for ${{ matrix.chain }}
-        working-directory: cumulus
+        working-directory: sdk
         run: |
             echo "::group::JSON digest"
             echo $JSON | jq . | tee ${{ matrix.chain }}-srtool-digest.json

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -171,7 +171,7 @@ jobs:
         env:
           PACKAGE: ${{ matrix.chain }}-runtime
           RUNTIME_DIR: polkadot/runtime/${{ matrix.chain }}
-        working-directory: polkadot
+        working-directory: sdk
         run: |
           ls -al runtime || true
           ls -al runtime/${{ matrix.chain }} || true
@@ -185,7 +185,7 @@ jobs:
         env:
           PACKAGE: ${{ matrix.chain }}-runtime
           RUNTIME_DIR: polkadot/runtime/${{ matrix.chain }}
-        working-directory: polkadot
+        working-directory: sdk
         run: |
           CMD="docker run --rm -i \
             -e PACKAGE=$PACKAGE \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -126,7 +126,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        chain: ["polkadot", "kusama", "westend"]
+        chain: ["westend"]
     steps:
       - name: Cache the image
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # v3.0.11
@@ -237,6 +237,158 @@ jobs:
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
         with:
           name: ${{ matrix.chain }}-runtime
+          path: |
+            polkadot/${{ steps.srtool_build.outputs.wasm }}
+            polkadot/${{ steps.srtool_build.outputs.wasm_compressed }}
+            polkadot/${{ matrix.chain }}-srtool-digest.json
+
+  fellowship:
+    runs-on: ubuntu-latest
+    needs: build
+    continue-on-error: false
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Relay
+          - runtime_dir: relay/kusama
+            runtime: kusama-runtime
+            chain: kusama
+          - runtime_dir: relay/polkadot
+            runtime: polkadot-runtime
+            chain: polkadot
+
+          # System parachains / Asset Hub
+          - runtime_dir: system-parachains/asset-hubs/asset-hub-kusama
+            runtime: asset-hub-kusama-runtime
+            chain: asset-hub-kusama
+          - runtime_dir: system-parachains/asset-hubs/asset-hub-polkadot
+            runtime: asset-hub-polkadot-runtime
+            chain: asset-hub-polkadot
+
+          # System parachains / Bridge Hub
+          - runtime_dir: system-parachains/bridge-hubs/bridge-hub-kusama
+            runtime: bridge-hub-kusama-runtime
+            chain: bridge-hub-kusama
+          - runtime_dir: system-parachains/bridge-hubs/bridge-hub-polkadot
+            runtime: bridge-hub-polkadot-runtime
+            chain: bridge-hub-polkadot
+
+          # System parachains / Collectives
+          - runtime_dir: system-parachains/collectives/collectives-polkadot
+            runtime: collectives-polkadot-runtime
+            chain: collectives-polkadot
+
+    steps:
+      - name: Cache the image
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # v3.0.11
+        with:
+          key: srtool-docker-image-${{ github.sha }}
+          path: |
+            srtool.tar.gz
+
+      - name: Load Docker image
+        run: |
+          docker load -i srtool.tar.gz
+          docker images --digests
+
+      - name: Check out the Fellowship repo
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        with:
+          repository: polkadot-fellows/runtimes
+          ref: ${{ github.event.inputs.ref }}
+          fetch-depth: 0
+          path: fellowship
+
+      - name: Run srtool info
+        env:
+          PACKAGE: ${{ matrix.runtime }}
+          RUNTIME_DIR: ${{ matrix.runtime_dir }}
+        working-directory: fellowship
+        run: |
+          INFO=$(docker run --rm -i \
+            -e PACKAGE=$PACKAGE \
+            -e RUNTIME_DIR=$RUNTIME_DIR \
+            -v "${PWD}":/build \
+            srtool info -cM)
+
+          if [ $( echo $INFO | jq .src -r ) != "git"  ] ; then
+            echo Invalid info output, got $( echo $INFO | jq .src -r )
+            exit 1
+          else
+            echo $INFO
+          fi
+
+      - name: Debugging
+        env:
+          PACKAGE: ${{ matrix.runtime }}
+          RUNTIME_DIR: ${{ matrix.runtime_dir }}
+        working-directory: fellowship
+        run: |
+          ls -al runtime || true
+          ls -al runtime/${{ matrix.chain }} || true
+          id -u runner || true
+          id -g runner || true
+          id -u docker || true
+          docker info --format "{{ .ClientInfo.Context }}"
+
+      - name: Run srtool build for ${{ matrix.chain }}
+        id: srtool_build
+        env:
+          PACKAGE: ${{ matrix.runtime }}
+          RUNTIME_DIR: ${{ matrix.runtime_dir }}
+        working-directory: fellowship
+        run: |
+          CMD="docker run --rm -i \
+            -e PACKAGE=$PACKAGE \
+            -e RUNTIME_DIR=$RUNTIME_DIR \
+            -v ${PWD}:/build \
+            srtool build --app --json"
+          echo ::debug::build::docker_run $CMD
+
+          echo "::group::SRTOOL Build Output"
+          stdbuf -oL $CMD | {
+            while IFS= read -r line
+            do
+              echo ║ $line
+              JSON="$line"
+            done
+
+            echo "json=$JSON" >> $GITHUB_OUTPUT
+            echo "JSON=$JSON" >> $GITHUB_ENV
+
+            echo $JSON | jq .
+
+            WASM=`echo $JSON | jq -r .runtimes.compact.wasm`
+            echo "wasm=$WASM" >> $GITHUB_OUTPUT
+
+            Z_WASM=`echo $JSON | jq -r .runtimes.compressed.wasm`
+            echo "wasm_compressed=$Z_WASM" >> $GITHUB_OUTPUT
+          }
+          echo "::endgroup::"
+
+      - name: Summary for ${{ matrix.chain }}
+        working-directory: fellowship
+        run: |
+          echo "::group::JSON digest"
+          echo $JSON | jq . | tee ${{ matrix.chain }}-srtool-digest.json
+          echo "::endgroup::"
+
+          echo "::group::Runtimes paths"
+          echo "Compact Runtime: ${{ steps.srtool_build.outputs.wasm }}"
+          echo "Compressed Runtime: ${{ steps.srtool_build.outputs.wasm_compressed }}"
+          echo "::endgroup::"
+
+          echo "::group::Debugging"
+          pwd; ls -al
+          ls -al ${{ steps.srtool_build.outputs.wasm_compressed }}
+          ls -al ${{ steps.srtool_build.outputs.wasm_compressed }}
+          echo "::endgroup::"
+
+      - name: Archive Artifacts for ${{ matrix.chain }}
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+        with:
+          name: ${{ matrix.runtime }}
           path: |
             polkadot/${{ steps.srtool_build.outputs.wasm }}
             polkadot/${{ steps.srtool_build.outputs.wasm_compressed }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "cSpell.words": [
+        "paritytech",
         "RUSTC",
         "srtool"
     ]


### PR DESCRIPTION
This PR switches some of the runtime from being build from the former substrate/polkadot/cumulus repos and switches to using the new [Polkadot SDK](https://github.com/paritytech/polkadot-sdk)