### PR TITLE
rustup component add rust-src

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,7 @@ RUN echo $SHELL && \
     . $CARGO_HOME/env && \
     rustup toolchain add stable ${RUSTC_VERSION} && \
     rustup target add wasm32-unknown-unknown --toolchain $RUSTC_VERSION && \
+    rustup component add rust-src --toolchain $RUSTC_VERSION && \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME && \
     rustup show && rustc -V
 


### PR DESCRIPTION
```
  Cannot compile the WASM runtime: no standard library sources found!
  You can install them with `rustup component add rust-src` if you're using `rustup`.
```