### PR TITLE
Adjust `Manual Build - Polkadot SDK` github flow

### DIFF
--- a/.github/workflows/manual-polkadot-sdk.yml
+++ b/.github/workflows/manual-polkadot-sdk.yml
@@ -75,7 +75,7 @@ jobs:
         if: ${{ steps.cache_runtimes_list.outputs.cache-hit != 'true' }}
 
         env:
-          EXCLUDED_RUNTIMES: "substrate-test"
+          EXCLUDED_RUNTIMES: "substrate-test bp cumulus-test kitchensink polkadot-test sp"
         run: |
           . ./srtool/scripts/lib.sh
 

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -40,7 +40,7 @@ function relative_parent() {
 # used as Github Workflow Matrix. This call is exposed by the `scan` command and can be used as:
 # podman run --rm -it -v /.../fellowship-runtimes:/build docker.io/chevdor/srtool:1.70.0-0.11.1 scan
 function find_runtimes() {
-    libs=($(git grep -I -r --cached --max-depth 20 --files-with-matches 'construct_runtime!' -- '*lib.rs'))
+    libs=($(git grep -I -r --cached --max-depth 20 --files-with-matches '[frame_support::runtime]!' -- '*lib.rs'))
     re=".*-runtime$"
     JSON=$(jq --null-input '{ "include": [] }')
 


### PR DESCRIPTION
This PR adjusts the github flow, which builds the runtimes for the `polkadot-sdk` repo.
Changes:
- include `westend-runtime` into the build
- exclude some of the test runtimes