### PR TITLE
fix: install WASM target for non-default RUSTC versions

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -53,6 +53,8 @@ fi
 
 # The following is to prevent user's overrides to disturb srtool
 rustup override set $RUSTC_VERSION
+rustup target add wasm32-unknown-unknown
+rustup component add rust-src
 
 export RUSTCV=`rustc -V`
 


### PR DESCRIPTION
If I try to specify a different `RUSTC` version than the one the container was built with, I guess an error when compiling the runtime: `Cannot compile the WASM runtime: the `wasm32-unknown-unknown` target is not installed!`. The link to the failing Gitlab pipeline is here: https://gitlab.com/kiltprotocol/kilt-node/-/jobs/8516236006.

If I try to add the relevant `rustup` instruction myself in the image setup step, I get the error `/usr/bin/bash: line 166: rustup: command not found`. A link to the failing pipeline is here: https://gitlab.com/kiltprotocol/kilt-node/-/jobs/8516444684.

Hence I believe the fix is to add the `wasm32-unknown-unknown` target by default after overriding the rustc info.