### PR TITLE
Use commit hash instead of branch name to check out the polkadot-sdk repo and add the hash to the job run name

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Get commit hash for ${{ github.event.inputs.repository }} ${{ github.event.inputs.ref }}
         id: getsha
-        working-directory: ${{ github.event.inputs.repository }}
+        working-directory: polkadot-sdk
         run: |
           echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -44,9 +44,6 @@ on:
 
 jobs:
   build:
-    outputs:
-      polkadot_sdk_checkout_hash: ${{ steps.getsha.outputs.sha }}
-
     name: Build ${{ github.event.inputs.repository }}/${{ github.event.inputs.package }} ${{ github.event.inputs.ref }}
     runs-on: ubuntu-latest
     steps:
@@ -57,15 +54,16 @@ jobs:
           fetch-depth: 0
 
       - name: Get commit hash for ${{ github.event.inputs.repository }} ${{ github.event.inputs.ref }}
-        id: getsha
         run: |
           sha=$(git rev-parse --short HEAD)
           echo "sha: $sha"
-          echo "sha=$sha" >> $GITHUB_OUTPUT
-      - name: Debug SDK SHA
-        run: |
-            echo "Building with SDK SHA: ${{ steps.getsha.outputs.sha }}"
+          echo "$sha" > sdk-checkout-sha.txt
 
+      - name: Upload SHA artifact
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 #v5.0.0
+        with:
+          name: sdk-checkout-sha
+          path: sdk-checkout-sha.txt
 
       # - name: Srtool build
       #   id: srtool_build
@@ -117,7 +115,7 @@ jobs:
       #     subwasm diff ${{ steps.srtool_build.outputs.wasm }} --chain-b ${{ github.event.inputs.chain }} | tee ${{ github.event.inputs.chain }}-diff.txt
 
       # - name: Archive Subwasm results
-      #   uses: actions/upload-artifact@v4
+      #   uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 #v5.0.0
       #   with:
       #     name: ${{ github.event.inputs.chain }}-runtime-info
       #     path: |

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -55,6 +55,7 @@ jobs:
 
       - name: Get commit hash for ${{ github.event.inputs.repository }} ${{ github.event.inputs.ref }}
         run: |
+          # The sha from the polkadot-sdk checkout will be used later to connect a runtime build with the uplaoded artifact
           sha=$(git rev-parse --short HEAD)
           echo "sha: $sha"
           echo "$sha" > sdk-checkout-sha.txt
@@ -65,61 +66,61 @@ jobs:
           name: sdk-checkout-sha
           path: sdk-checkout-sha.txt
 
-      # - name: Srtool build
-      #   id: srtool_build
-      #   uses: chevdor/srtool-actions@v0.9.2
-      #   env:
-      #     BUILD_OPTS: ${{ inputs.build_opts }}
-      #   with:
-      #     chain: ${{ github.event.inputs.chain }}
-      #     package: ${{ github.event.inputs.package }}
-      #     image: ${{ github.event.inputs.srtool_image }}
-      #     tag: ${{ github.event.inputs.srtool_tag }}
-      #     runtime_dir: ${{ github.event.inputs.runtime_dir }}
-      #     profile: ${{ github.event.inputs.profile }}
+      - name: Srtool build
+        id: srtool_build
+        uses: chevdor/srtool-actions@v0.9.2
+        env:
+          BUILD_OPTS: ${{ inputs.build_opts }}
+        with:
+          chain: ${{ github.event.inputs.chain }}
+          package: ${{ github.event.inputs.package }}
+          image: ${{ github.event.inputs.srtool_image }}
+          tag: ${{ github.event.inputs.srtool_tag }}
+          runtime_dir: ${{ github.event.inputs.runtime_dir }}
+          profile: ${{ github.event.inputs.profile }}
 
-      # - name: Summary
-      #   run: |
-      #     echo '${{ steps.srtool_build.outputs.json }}' | jq > ${{ github.event.inputs.chain }}-srtool-digest.json
-      #     cat ${{ github.event.inputs.chain }}-srtool-digest.json
-      #     echo "Runtime location: ${{ steps.srtool_build.outputs.wasm }}"
+      - name: Summary
+        run: |
+          echo '${{ steps.srtool_build.outputs.json }}' | jq > ${{ github.event.inputs.chain }}-srtool-digest.json
+          cat ${{ github.event.inputs.chain }}-srtool-digest.json
+          echo "Runtime location: ${{ steps.srtool_build.outputs.wasm }}"
 
-      # # it takes a while to build the runtime, so let's save the artifact as soon as we have it
-      # - name: Archive Artifacts for ${{ github.event.inputs.chain }}
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: ${{ github.event.inputs.chain }}-runtime
-      #     path: |
-      #       ${{ steps.srtool_build.outputs.wasm }}
-      #       ${{ steps.srtool_build.outputs.wasm_compressed }}
-      #       ${{ github.event.inputs.chain }}-srtool-digest.json
+      # it takes a while to build the runtime, so let's save the artifact as soon as we have it
+      - name: Archive Artifacts for ${{ github.event.inputs.chain }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.event.inputs.chain }}-runtime
+          path: |
+            ${{ steps.srtool_build.outputs.wasm }}
+            ${{ steps.srtool_build.outputs.wasm_compressed }}
+            ${{ github.event.inputs.chain }}-srtool-digest.json
 
-      # # We now get extra information thanks to subwasm,
-      # - name: Install subwasm ${{ env.SUBWASM_VERSION }}
-      #   run: |
-      #     wget https://github.com/chevdor/subwasm/releases/download/v${{ env.SUBWASM_VERSION }}/subwasm_linux_amd64_v${{ env.SUBWASM_VERSION }}.deb
-      #     sudo dpkg -i subwasm_linux_amd64_v${{ env.SUBWASM_VERSION }}.deb
-      #     subwasm --version
-      # - name: Show Runtime information
-      #   run: |
-      #     subwasm info ${{ steps.srtool_build.outputs.wasm }}
-      #     subwasm info ${{ steps.srtool_build.outputs.wasm_compressed }}
-      #     subwasm --json info ${{ steps.srtool_build.outputs.wasm }} > ${{ github.event.inputs.chain }}-info.json
-      #     subwasm --json info ${{ steps.srtool_build.outputs.wasm_compressed }} > ${{ github.event.inputs.chain }}-info_compressed.json
-      # - name: Extract the metadata
-      #   run: |
-      #     subwasm meta ${{ steps.srtool_build.outputs.wasm }}
-      #     subwasm --json meta ${{ steps.srtool_build.outputs.wasm }} > ${{ github.event.inputs.chain }}-metadata.json
-      # - name: Check the metadata diff
-      #   run: |
-      #     subwasm diff ${{ steps.srtool_build.outputs.wasm }} --chain-b ${{ github.event.inputs.chain }} | tee ${{ github.event.inputs.chain }}-diff.txt
+      # We now get extra information thanks to subwasm,
+      - name: Install subwasm ${{ env.SUBWASM_VERSION }}
+        run: |
+          wget https://github.com/chevdor/subwasm/releases/download/v${{ env.SUBWASM_VERSION }}/subwasm_linux_amd64_v${{ env.SUBWASM_VERSION }}.deb
+          sudo dpkg -i subwasm_linux_amd64_v${{ env.SUBWASM_VERSION }}.deb
+          subwasm --version
+      - name: Show Runtime information
+        run: |
+          subwasm info ${{ steps.srtool_build.outputs.wasm }}
+          subwasm info ${{ steps.srtool_build.outputs.wasm_compressed }}
+          subwasm --json info ${{ steps.srtool_build.outputs.wasm }} > ${{ github.event.inputs.chain }}-info.json
+          subwasm --json info ${{ steps.srtool_build.outputs.wasm_compressed }} > ${{ github.event.inputs.chain }}-info_compressed.json
+      - name: Extract the metadata
+        run: |
+          subwasm meta ${{ steps.srtool_build.outputs.wasm }}
+          subwasm --json meta ${{ steps.srtool_build.outputs.wasm }} > ${{ github.event.inputs.chain }}-metadata.json
+      - name: Check the metadata diff
+        run: |
+          subwasm diff ${{ steps.srtool_build.outputs.wasm }} --chain-b ${{ github.event.inputs.chain }} | tee ${{ github.event.inputs.chain }}-diff.txt
 
-      # - name: Archive Subwasm results
-      #   uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 #v5.0.0
-      #   with:
-      #     name: ${{ github.event.inputs.chain }}-runtime-info
-      #     path: |
-      #       ${{ github.event.inputs.chain }}-info.json
-      #       ${{ github.event.inputs.chain }}-info_compressed.json
-      #       ${{ github.event.inputs.chain }}-metadata.json
-      #       ${{ github.event.inputs.chain }}-diff.txt
+      - name: Archive Subwasm results
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 #v5.0.0
+        with:
+          name: ${{ github.event.inputs.chain }}-runtime-info
+          path: |
+            ${{ github.event.inputs.chain }}-info.json
+            ${{ github.event.inputs.chain }}-info_compressed.json
+            ${{ github.event.inputs.chain }}-metadata.json
+            ${{ github.event.inputs.chain }}-diff.txt

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -58,7 +58,6 @@ jobs:
 
       - name: Get commit hash for ${{ github.event.inputs.repository }} ${{ github.event.inputs.ref }}
         id: getsha
-        working-directory: polkadot-sdk
         run: |
           echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -53,19 +53,6 @@ jobs:
           ref: ${{ github.event.inputs.ref }}
           fetch-depth: 0
 
-      - name: Get commit hash for ${{ github.event.inputs.repository }} ${{ github.event.inputs.ref }}
-        run: |
-          # The sha from the polkadot-sdk checkout will be used later to connect a runtime build with the uplaoded artifact
-          sha=$(git rev-parse --short HEAD)
-          echo "sha: $sha"
-          echo "$sha" > sdk-checkout-sha.txt
-
-      - name: Upload SHA artifact
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 #v5.0.0
-        with:
-          name: sdk-checkout-sha
-          path: sdk-checkout-sha.txt
-
       - name: Srtool build
         id: srtool_build
         uses: chevdor/srtool-actions@v0.9.2

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -44,6 +44,9 @@ on:
 
 jobs:
   build:
+    outputs:
+      polkadot_sdk_checkout_hash: ${{ steps.getsha.outputs.sha }}
+
     name: Build ${{ github.event.inputs.repository }}/${{ github.event.inputs.package }} ${{ github.event.inputs.ref }}
     runs-on: ubuntu-latest
     steps:
@@ -53,61 +56,67 @@ jobs:
           ref: ${{ github.event.inputs.ref }}
           fetch-depth: 0
 
-      - name: Srtool build
-        id: srtool_build
-        uses: chevdor/srtool-actions@v0.9.2
-        env:
-          BUILD_OPTS: ${{ inputs.build_opts }}
-        with:
-          chain: ${{ github.event.inputs.chain }}
-          package: ${{ github.event.inputs.package }}
-          image: ${{ github.event.inputs.srtool_image }}
-          tag: ${{ github.event.inputs.srtool_tag }}
-          runtime_dir: ${{ github.event.inputs.runtime_dir }}
-          profile: ${{ github.event.inputs.profile }}
+      - name: Get commit hash for ${{ github.event.inputs.repository }} ${{ github.event.inputs.ref }}
+        id: getsha
+        working-directory: ${{ github.event.inputs.repository }}
+        run: |
+          echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
-      - name: Summary
-        run: |
-          echo '${{ steps.srtool_build.outputs.json }}' | jq > ${{ github.event.inputs.chain }}-srtool-digest.json
-          cat ${{ github.event.inputs.chain }}-srtool-digest.json
-          echo "Runtime location: ${{ steps.srtool_build.outputs.wasm }}"
+      # - name: Srtool build
+      #   id: srtool_build
+      #   uses: chevdor/srtool-actions@v0.9.2
+      #   env:
+      #     BUILD_OPTS: ${{ inputs.build_opts }}
+      #   with:
+      #     chain: ${{ github.event.inputs.chain }}
+      #     package: ${{ github.event.inputs.package }}
+      #     image: ${{ github.event.inputs.srtool_image }}
+      #     tag: ${{ github.event.inputs.srtool_tag }}
+      #     runtime_dir: ${{ github.event.inputs.runtime_dir }}
+      #     profile: ${{ github.event.inputs.profile }}
 
-      # it takes a while to build the runtime, so let's save the artifact as soon as we have it
-      - name: Archive Artifacts for ${{ github.event.inputs.chain }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ github.event.inputs.chain }}-runtime
-          path: |
-            ${{ steps.srtool_build.outputs.wasm }}
-            ${{ steps.srtool_build.outputs.wasm_compressed }}
-            ${{ github.event.inputs.chain }}-srtool-digest.json
+      # - name: Summary
+      #   run: |
+      #     echo '${{ steps.srtool_build.outputs.json }}' | jq > ${{ github.event.inputs.chain }}-srtool-digest.json
+      #     cat ${{ github.event.inputs.chain }}-srtool-digest.json
+      #     echo "Runtime location: ${{ steps.srtool_build.outputs.wasm }}"
 
-      # We now get extra information thanks to subwasm,
-      - name: Install subwasm ${{ env.SUBWASM_VERSION }}
-        run: |
-          wget https://github.com/chevdor/subwasm/releases/download/v${{ env.SUBWASM_VERSION }}/subwasm_linux_amd64_v${{ env.SUBWASM_VERSION }}.deb
-          sudo dpkg -i subwasm_linux_amd64_v${{ env.SUBWASM_VERSION }}.deb
-          subwasm --version
-      - name: Show Runtime information
-        run: |
-          subwasm info ${{ steps.srtool_build.outputs.wasm }}
-          subwasm info ${{ steps.srtool_build.outputs.wasm_compressed }}
-          subwasm --json info ${{ steps.srtool_build.outputs.wasm }} > ${{ github.event.inputs.chain }}-info.json
-          subwasm --json info ${{ steps.srtool_build.outputs.wasm_compressed }} > ${{ github.event.inputs.chain }}-info_compressed.json
-      - name: Extract the metadata
-        run: |
-          subwasm meta ${{ steps.srtool_build.outputs.wasm }}
-          subwasm --json meta ${{ steps.srtool_build.outputs.wasm }} > ${{ github.event.inputs.chain }}-metadata.json
-      - name: Check the metadata diff
-        run: |
-          subwasm diff ${{ steps.srtool_build.outputs.wasm }} --chain-b ${{ github.event.inputs.chain }} | tee ${{ github.event.inputs.chain }}-diff.txt
+      # # it takes a while to build the runtime, so let's save the artifact as soon as we have it
+      # - name: Archive Artifacts for ${{ github.event.inputs.chain }}
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: ${{ github.event.inputs.chain }}-runtime
+      #     path: |
+      #       ${{ steps.srtool_build.outputs.wasm }}
+      #       ${{ steps.srtool_build.outputs.wasm_compressed }}
+      #       ${{ github.event.inputs.chain }}-srtool-digest.json
 
-      - name: Archive Subwasm results
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ github.event.inputs.chain }}-runtime-info
-          path: |
-            ${{ github.event.inputs.chain }}-info.json
-            ${{ github.event.inputs.chain }}-info_compressed.json
-            ${{ github.event.inputs.chain }}-metadata.json
-            ${{ github.event.inputs.chain }}-diff.txt
+      # # We now get extra information thanks to subwasm,
+      # - name: Install subwasm ${{ env.SUBWASM_VERSION }}
+      #   run: |
+      #     wget https://github.com/chevdor/subwasm/releases/download/v${{ env.SUBWASM_VERSION }}/subwasm_linux_amd64_v${{ env.SUBWASM_VERSION }}.deb
+      #     sudo dpkg -i subwasm_linux_amd64_v${{ env.SUBWASM_VERSION }}.deb
+      #     subwasm --version
+      # - name: Show Runtime information
+      #   run: |
+      #     subwasm info ${{ steps.srtool_build.outputs.wasm }}
+      #     subwasm info ${{ steps.srtool_build.outputs.wasm_compressed }}
+      #     subwasm --json info ${{ steps.srtool_build.outputs.wasm }} > ${{ github.event.inputs.chain }}-info.json
+      #     subwasm --json info ${{ steps.srtool_build.outputs.wasm_compressed }} > ${{ github.event.inputs.chain }}-info_compressed.json
+      # - name: Extract the metadata
+      #   run: |
+      #     subwasm meta ${{ steps.srtool_build.outputs.wasm }}
+      #     subwasm --json meta ${{ steps.srtool_build.outputs.wasm }} > ${{ github.event.inputs.chain }}-metadata.json
+      # - name: Check the metadata diff
+      #   run: |
+      #     subwasm diff ${{ steps.srtool_build.outputs.wasm }} --chain-b ${{ github.event.inputs.chain }} | tee ${{ github.event.inputs.chain }}-diff.txt
+
+      # - name: Archive Subwasm results
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: ${{ github.event.inputs.chain }}-runtime-info
+      #     path: |
+      #       ${{ github.event.inputs.chain }}-info.json
+      #       ${{ github.event.inputs.chain }}-info_compressed.json
+      #       ${{ github.event.inputs.chain }}-metadata.json
+      #       ${{ github.event.inputs.chain }}-diff.txt

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -59,7 +59,13 @@ jobs:
       - name: Get commit hash for ${{ github.event.inputs.repository }} ${{ github.event.inputs.ref }}
         id: getsha
         run: |
-          echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          sha=$(git rev-parse --short HEAD)
+          echo "sha: $sha"
+          echo "sha=$sha" >> $GITHUB_OUTPUT
+      - name: Debug SDK SHA
+        run: |
+            echo "Building with SDK SHA: ${{ steps.getsha.outputs.sha }}"
+
 
       # - name: Srtool build
       #   id: srtool_build

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -1,5 +1,6 @@
 name: Manual Build
 
+run-name: Build for ${{ github.event.inputs.ref }}
 env:
   SUBWASM_VERSION: 0.21.0
 
@@ -31,8 +32,7 @@ on:
         default: polkadot/runtime/westend
         required: true
       ref:
-        description: The ref to be used for the repo
-        default: master
+        description: The github commit hash to be used for the repo to be built from (this should be a commit hash and not a branch name)
         required: false
       build_opts:
         description: The build options to be used to build runtime e.g. --features on-chain-release-build (can be left empty)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -347,7 +347,7 @@ jobs:
           CMD="docker run --rm -i \
             -e PACKAGE=$PACKAGE \
             -e RUNTIME_DIR=$RUNTIME_DIR \
-            -e RUSTC_VERSION=1.81.0 \
+            -e RUSTC_VERSION=1.88.0 \
             -e WASM_BUILD_STD=0 \
             -v ${PWD}:/build \
             srtool build --app --json"


### PR DESCRIPTION
This will help us to trace the runtime build and use it further for the upload to gcp and deployment on westend