### PR TITLE
Bump gha versions and fix scheduled run

### DIFF
--- a/.github/workflows/manual-acala.yml
+++ b/.github/workflows/manual-acala.yml
@@ -25,7 +25,7 @@ jobs:
         chain: ["karura"]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: AcalaNetwork/Acala
           ref: ${{ github.event.inputs.ref }}
@@ -47,7 +47,7 @@ jobs:
 
       # it takes a while to build the runtime, so let's save the artifact as soon as we have it
       - name: Archive Artifacts for ${{ matrix.chain }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.chain }}-runtime
           path: |
@@ -76,7 +76,7 @@ jobs:
           subwasm diff ${{ steps.srtool_build.outputs.wasm }} --chain-b ${{ matrix.chain }} | tee ${{ matrix.chain }}-diff.txt
 
       - name: Archive Subwasm results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.chain }}-runtime-info
           path: |

--- a/.github/workflows/manual-fellow-runtimes.yml
+++ b/.github/workflows/manual-fellow-runtimes.yml
@@ -37,13 +37,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the srtool repo
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           path: srtool
 
       - name: Checkout repo ${{ inputs.repo }}
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.ref }}
@@ -59,7 +59,7 @@ jobs:
       - name: Cache runtimes list for ${{ steps.get_commit_hash.outputs.commit_hash }}
         id: cache_runtimes_list
         if: inputs.cache == 'true'
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: runtimes-list-${{ steps.get_commit_hash.outputs.commit_hash }}
           path: |
@@ -106,14 +106,14 @@ jobs:
       - name: Cache ${{ matrix.chain }} runtime for ${{ needs.find-runtimes.outputs.commit_hash }}
         id: cache_runtime
         if: inputs.cache == 'true'
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: ${{ matrix.chain }}-${{ needs.find-runtimes.outputs.commit_hash }}
           path: |
             fellows-runtimes/${{ matrix.runtime_dir }}/target/srtool/release/wbuild/${{ matrix.chain }}-runtime
 
       - name: Checkout
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         if: ${{ steps.cache_runtime.outputs.cache-hit != 'true' }}
         with:
           repository: ${{ inputs.repo }}
@@ -170,7 +170,7 @@ jobs:
 
       # it takes a while to build the runtime, so let's save the artifact as soon as we have it
       - name: Archive Artifacts for ${{ matrix.chain }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.chain }}-runtime
           path: |
@@ -205,7 +205,7 @@ jobs:
           subwasm diff ${{ steps.get_values.outputs.wasm }} --chain-b ${{ matrix.chain }} | tee ${{ matrix.chain }}-diff.txt
 
       - name: Archive Subwasm results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.chain }}-runtime-info
           path: |

--- a/.github/workflows/manual-moonbeam.yml
+++ b/.github/workflows/manual-moonbeam.yml
@@ -25,7 +25,7 @@ jobs:
         chain: ["moonriver"]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: PureStake/moonbeam
           ref: ${{ github.event.inputs.ref }}
@@ -46,7 +46,7 @@ jobs:
 
       # it takes a while to build the runtime, so let's save the artifact as soon as we have it
       - name: Archive Artifacts for ${{ matrix.chain }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.chain }}-runtime
           path: |
@@ -76,7 +76,7 @@ jobs:
           echo "No live chain to compare" > ${{ matrix.chain }}-diff.txt
 
       - name: Archive Subwasm results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.chain }}-runtime-info
           path: |

--- a/.github/workflows/manual-polkadot-sdk.yml
+++ b/.github/workflows/manual-polkadot-sdk.yml
@@ -42,16 +42,27 @@ jobs:
     outputs:
       runtime: ${{ steps.get_runtimes_list.outputs.runtime }}
       commit_hash: ${{ steps.get_commit_hash.outputs.commit_hash }}
+      srtool_tag: ${{ steps.get_srtool_tag.outputs.srtool_tag }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the srtool repo
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           path: srtool
 
+      - name: Determine the SRTOOL tag
+        id: get_srtool_tag
+        run: |
+          # Use the tag provided on manual dispatch, otherwise fall back to the
+          # RUSTC_VERSION pinned in this repo (e.g. on scheduled runs).
+          srtool_tag="${{ github.event.inputs.srtool_tag }}"
+          srtool_tag="${srtool_tag:-$(cat srtool/RUSTC_VERSION)}"
+          echo "Using SRTOOL tag: $srtool_tag"
+          echo "srtool_tag=$srtool_tag" >> $GITHUB_OUTPUT
+
       - name: Checkout repo ${{ inputs.repo }}
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: paritytech/polkadot-sdk
           ref: ${{ github.event.inputs.ref }}
@@ -67,7 +78,7 @@ jobs:
       - name: Cache runtimes list for ${{ steps.get_commit_hash.outputs.commit_hash }}
         id: cache_runtimes_list
         if: github.event.inputs.cache == 'true'
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: runtimes-list-${{ steps.get_commit_hash.outputs.commit_hash }}
           path: |
@@ -114,7 +125,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: paritytech/polkadot-sdk
           fetch-depth: 0
@@ -132,25 +143,25 @@ jobs:
       - name: Cache ${{ matrix.chain }} runtime for ${{ needs.find-runtimes.outputs.commit_hash }}
         id: cache_runtime
         if: github.event.inputs.cache == 'true'
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: ${{ matrix.chain }}-${{ needs.find-runtimes.outputs.commit_hash }}
           path: |
-            sdk/${{ matrix.runtime_dir }}/target/srtool/${{ inputs.profile }}/wbuild/${{ matrix.chain }}-runtime
+            sdk/${{ matrix.runtime_dir }}/target/srtool/${{ inputs.profile || 'release' }}/wbuild/${{ matrix.chain }}-runtime
 
       - name: Srtool build
         id: srtool_build
         if: ${{ steps.cache_runtime.outputs.cache-hit != 'true' }}
         uses: chevdor/srtool-actions@v0.9.2
         env:
-          BUILD_OPTS: ${{ inputs.build_opts }}
+          BUILD_OPTS: ${{ inputs.build_opts || '--features on-chain-release-build' }}
         with:
           workdir: sdk
           chain: ${{ matrix.chain }}
           runtime_dir: ${{ matrix.runtime_dir }}
-          image: ${{ github.event.inputs.image }}
-          tag: ${{ github.event.inputs.srtool_tag }}
-          profile: ${{ github.event.inputs.profile }}
+          image: ${{ github.event.inputs.image || 'paritytech/srtool' }}
+          tag: ${{ needs.find-runtimes.outputs.srtool_tag }}
+          profile: ${{ github.event.inputs.profile || 'production' }}
 
       # This is done to allow caching
       - name: Store build artifacts to disk
@@ -158,7 +169,7 @@ jobs:
         if: ${{ steps.cache_runtime.outputs.cache-hit != 'true' }}
         working-directory: sdk
         run: |
-          cached_output=${{ matrix.runtime_dir }}/target/srtool/${{ inputs.profile }}/wbuild/${{ matrix.chain }}-runtime/
+          cached_output=${{ matrix.runtime_dir }}/target/srtool/${{ inputs.profile || 'production' }}/wbuild/${{ matrix.chain }}-runtime/
           digest_file=${cached_output}/${{ matrix.chain }}-srtool-digest.json
           echo '${{ steps.srtool_build.outputs.json }}' | jq > ${digest_file}
           cat ${digest_file}
@@ -170,9 +181,9 @@ jobs:
           runtime_package=${{ matrix.chain }}-runtime
           runtime_filename=${runtime_package//-/_}
 
-          wasm="${{ matrix.runtime_dir }}/target/srtool/${{ inputs.profile }}/wbuild/${runtime_package}/${runtime_filename}.compact.wasm"
+          wasm="${{ matrix.runtime_dir }}/target/srtool/${{ inputs.profile || 'production' }}/wbuild/${runtime_package}/${runtime_filename}.compact.wasm"
 
-          wasm_compressed="${{ matrix.runtime_dir }}/target/srtool/${{ inputs.profile }}/wbuild/${runtime_package}/${runtime_filename}.compact.compressed.wasm"
+          wasm_compressed="${{ matrix.runtime_dir }}/target/srtool/${{ inputs.profile || 'production' }}/wbuild/${runtime_package}/${runtime_filename}.compact.compressed.wasm"
 
           # we need wasm and wasm_compressed
           echo "wasm=$wasm" >> "$GITHUB_OUTPUT"
@@ -181,7 +192,7 @@ jobs:
       - name: Summary
         working-directory: sdk
         run: |
-          cached_output=${{ matrix.runtime_dir }}/target/srtool/${{ inputs.profile }}/wbuild/${{ matrix.chain }}-runtime/
+          cached_output=${{ matrix.runtime_dir }}/target/srtool/${{ inputs.profile || 'production' }}/wbuild/${{ matrix.chain }}-runtime/
           digest_file=${cached_output}/${{ matrix.chain }}-srtool-digest.json
           ls -al ${digest_file}
           cat ${digest_file}
@@ -190,7 +201,7 @@ jobs:
 
       # it takes a while to build the runtime, so let's save the artifact as soon as we have it
       - name: Archive Artifacts for ${{ matrix.chain }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.chain }}-runtime
           path: |
@@ -219,7 +230,7 @@ jobs:
           subwasm meta --format=json ${{ steps.get_values.outputs.wasm }} | tee ${{ matrix.chain }}-metadata.json
 
       - name: Archive Subwasm information
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.chain }}-runtime-info
           path: |
@@ -251,7 +262,7 @@ jobs:
 
       - name: Archive Subwasm diff
         if: steps.check-reference-chain.outputs.ref_chain_found == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.chain }}-runtime-diff
           path: |

--- a/.github/workflows/manual-polkadot-sdk.yml
+++ b/.github/workflows/manual-polkadot-sdk.yml
@@ -31,7 +31,7 @@ on:
         required: false
       profile:
         description: The profile to be used for the runtime build
-        default: release
+        default: production
         required: false
   schedule:
     - cron: "00 03 * * 1" # 3AM weekly on mondays
@@ -42,16 +42,27 @@ jobs:
     outputs:
       runtime: ${{ steps.get_runtimes_list.outputs.runtime }}
       commit_hash: ${{ steps.get_commit_hash.outputs.commit_hash }}
+      srtool_tag: ${{ steps.get_srtool_tag.outputs.srtool_tag }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the srtool repo
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           path: srtool
 
+      - name: Determine the SRTOOL tag
+        id: get_srtool_tag
+        run: |
+          # Use the tag provided on manual dispatch, otherwise fall back to the
+          # RUSTC_VERSION pinned in this repo (e.g. on scheduled runs).
+          srtool_tag="${{ github.event.inputs.srtool_tag }}"
+          srtool_tag="${srtool_tag:-$(cat srtool/RUSTC_VERSION)}"
+          echo "Using SRTOOL tag: $srtool_tag"
+          echo "srtool_tag=$srtool_tag" >> $GITHUB_OUTPUT
+
       - name: Checkout repo ${{ inputs.repo }}
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: paritytech/polkadot-sdk
           ref: ${{ github.event.inputs.ref }}
@@ -67,7 +78,7 @@ jobs:
       - name: Cache runtimes list for ${{ steps.get_commit_hash.outputs.commit_hash }}
         id: cache_runtimes_list
         if: github.event.inputs.cache == 'true'
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: runtimes-list-${{ steps.get_commit_hash.outputs.commit_hash }}
           path: |
@@ -114,7 +125,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: paritytech/polkadot-sdk
           fetch-depth: 0
@@ -132,25 +143,25 @@ jobs:
       - name: Cache ${{ matrix.chain }} runtime for ${{ needs.find-runtimes.outputs.commit_hash }}
         id: cache_runtime
         if: github.event.inputs.cache == 'true'
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: ${{ matrix.chain }}-${{ needs.find-runtimes.outputs.commit_hash }}
           path: |
-            sdk/${{ matrix.runtime_dir }}/target/srtool/${{ inputs.profile }}/wbuild/${{ matrix.chain }}-runtime
+            sdk/${{ matrix.runtime_dir }}/target/srtool/${{ inputs.profile || 'production' }}/wbuild/${{ matrix.chain }}-runtime
 
       - name: Srtool build
         id: srtool_build
         if: ${{ steps.cache_runtime.outputs.cache-hit != 'true' }}
         uses: chevdor/srtool-actions@v0.9.2
         env:
-          BUILD_OPTS: ${{ inputs.build_opts }}
+          BUILD_OPTS: ${{ inputs.build_opts || '--features on-chain-release-build' }}
         with:
           workdir: sdk
           chain: ${{ matrix.chain }}
           runtime_dir: ${{ matrix.runtime_dir }}
-          image: ${{ github.event.inputs.image }}
-          tag: ${{ github.event.inputs.srtool_tag }}
-          profile: ${{ github.event.inputs.profile }}
+          image: ${{ github.event.inputs.image || 'paritytech/srtool' }}
+          tag: ${{ needs.find-runtimes.outputs.srtool_tag }}
+          profile: ${{ github.event.inputs.profile || 'production' }}
 
       # This is done to allow caching
       - name: Store build artifacts to disk
@@ -158,7 +169,7 @@ jobs:
         if: ${{ steps.cache_runtime.outputs.cache-hit != 'true' }}
         working-directory: sdk
         run: |
-          cached_output=${{ matrix.runtime_dir }}/target/srtool/${{ inputs.profile }}/wbuild/${{ matrix.chain }}-runtime/
+          cached_output=${{ matrix.runtime_dir }}/target/srtool/${{ inputs.profile || 'production' }}/wbuild/${{ matrix.chain }}-runtime/
           digest_file=${cached_output}/${{ matrix.chain }}-srtool-digest.json
           echo '${{ steps.srtool_build.outputs.json }}' | jq > ${digest_file}
           cat ${digest_file}
@@ -170,9 +181,9 @@ jobs:
           runtime_package=${{ matrix.chain }}-runtime
           runtime_filename=${runtime_package//-/_}
 
-          wasm="${{ matrix.runtime_dir }}/target/srtool/${{ inputs.profile }}/wbuild/${runtime_package}/${runtime_filename}.compact.wasm"
+          wasm="${{ matrix.runtime_dir }}/target/srtool/${{ inputs.profile || 'production' }}/wbuild/${runtime_package}/${runtime_filename}.compact.wasm"
 
-          wasm_compressed="${{ matrix.runtime_dir }}/target/srtool/${{ inputs.profile }}/wbuild/${runtime_package}/${runtime_filename}.compact.compressed.wasm"
+          wasm_compressed="${{ matrix.runtime_dir }}/target/srtool/${{ inputs.profile || 'production' }}/wbuild/${runtime_package}/${runtime_filename}.compact.compressed.wasm"
 
           # we need wasm and wasm_compressed
           echo "wasm=$wasm" >> "$GITHUB_OUTPUT"
@@ -181,7 +192,7 @@ jobs:
       - name: Summary
         working-directory: sdk
         run: |
-          cached_output=${{ matrix.runtime_dir }}/target/srtool/${{ inputs.profile }}/wbuild/${{ matrix.chain }}-runtime/
+          cached_output=${{ matrix.runtime_dir }}/target/srtool/${{ inputs.profile || 'production' }}/wbuild/${{ matrix.chain }}-runtime/
           digest_file=${cached_output}/${{ matrix.chain }}-srtool-digest.json
           ls -al ${digest_file}
           cat ${digest_file}
@@ -190,7 +201,7 @@ jobs:
 
       # it takes a while to build the runtime, so let's save the artifact as soon as we have it
       - name: Archive Artifacts for ${{ matrix.chain }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.chain }}-runtime
           path: |
@@ -219,7 +230,7 @@ jobs:
           subwasm meta --format=json ${{ steps.get_values.outputs.wasm }} | tee ${{ matrix.chain }}-metadata.json
 
       - name: Archive Subwasm information
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.chain }}-runtime-info
           path: |
@@ -251,7 +262,7 @@ jobs:
 
       - name: Archive Subwasm diff
         if: steps.check-reference-chain.outputs.ref_chain_found == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.chain }}-runtime-diff
           path: |

--- a/.github/workflows/manual-shiden.yml
+++ b/.github/workflows/manual-shiden.yml
@@ -25,7 +25,7 @@ jobs:
         chain: ["shiden"]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: AstarNetwork/Astar
           ref: ${{ github.event.inputs.ref }}
@@ -47,7 +47,7 @@ jobs:
 
       # it takes a while to build the runtime, so let's save the artifact as soon as we have it
       - name: Archive Artifacts for ${{ matrix.chain }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.chain }}-runtime
           path: |
@@ -77,7 +77,7 @@ jobs:
           echo "No live chain to compare" > ${{ matrix.chain }}-diff.txt
 
       - name: Archive Subwasm results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.chain }}-runtime-info
           path: |

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -47,7 +47,7 @@ jobs:
     name: Build ${{ github.event.inputs.repository }}/${{ github.event.inputs.package }} ${{ github.event.inputs.ref }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: ${{ github.event.inputs.repository }}
           ref: ${{ github.event.inputs.ref }}
@@ -74,7 +74,7 @@ jobs:
 
       # it takes a while to build the runtime, so let's save the artifact as soon as we have it
       - name: Archive Artifacts for ${{ github.event.inputs.chain }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ github.event.inputs.chain }}-runtime
           path: |
@@ -103,7 +103,7 @@ jobs:
           subwasm diff ${{ steps.srtool_build.outputs.wasm }} --chain-b ${{ github.event.inputs.chain }} | tee ${{ github.event.inputs.chain }}-diff.txt
 
       - name: Archive Subwasm results
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 #v5.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ github.event.inputs.chain }}-runtime-info
           path: |

--- a/.github/workflows/quick-test.yml
+++ b/.github/workflows/quick-test.yml
@@ -39,24 +39,22 @@ jobs:
         run: |
           docker save srtool | gzip > srtool.tar.gz
 
-      - name: Cache the image
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Upload image artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          key: srtool-docker-image-${{ github.sha }}
-          path: |
-            srtool.tar.gz
+          name: srtool-image
+          path: srtool.tar.gz
+          retention-days: 1
 
   common:
     runs-on: ubuntu-latest
     needs: build
     continue-on-error: false
     steps:
-      - name: Cache the image
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Download image artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          key: srtool-docker-image-${{ github.sha }}
-          path: |
-            srtool.tar.gz
+          name: srtool-image
 
       - name: Load Docker image
         run: |
@@ -90,12 +88,10 @@ jobs:
         run: |
           ls -al
 
-      - name: Cache the image
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Download image artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          key: srtool-docker-image-${{ github.sha }}
-          path: |
-            srtool.tar.gz
+          name: srtool-image
 
       - name: Install tooling
         run: |
@@ -129,12 +125,10 @@ jobs:
       matrix:
         chain: ["westend"]
     steps:
-      - name: Cache the image
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Download image artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          key: srtool-docker-image-${{ github.sha }}
-          path: |
-            srtool.tar.gz
+          name: srtool-image
 
       - name: Load Docker image
         run: |

--- a/.github/workflows/quick-test.yml
+++ b/.github/workflows/quick-test.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: false
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -40,7 +40,7 @@ jobs:
           docker save srtool | gzip > srtool.tar.gz
 
       - name: Cache the image
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: srtool-docker-image-${{ github.sha }}
           path: |
@@ -52,7 +52,7 @@ jobs:
     continue-on-error: false
     steps:
       - name: Cache the image
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: srtool-docker-image-${{ github.sha }}
           path: |
@@ -82,7 +82,7 @@ jobs:
     needs: build
     continue-on-error: false
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -91,7 +91,7 @@ jobs:
           ls -al
 
       - name: Cache the image
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: srtool-docker-image-${{ github.sha }}
           path: |
@@ -130,7 +130,7 @@ jobs:
         chain: ["westend"]
     steps:
       - name: Cache the image
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: srtool-docker-image-${{ github.sha }}
           path: |
@@ -142,7 +142,7 @@ jobs:
           docker images --digests
 
       - name: Check out the Polkadot SDK repo
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: paritytech/polkadot-sdk
           ref: ${{ github.event.inputs.ref }}
@@ -244,7 +244,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Archive Artifacts for ${{ matrix.chain }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.chain }}-runtime
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,12 +24,12 @@ jobs:
         run: |
           docker save srtool | gzip > srtool.tar.gz
 
-      - name: Cache the image
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Upload image artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          key: srtool-docker-image-${{ github.sha }}
-          path: |
-            srtool.tar.gz
+          name: srtool-image
+          path: srtool.tar.gz
+          retention-days: 1
 
   create_draft:
     needs: ["build"]
@@ -51,12 +51,6 @@ jobs:
           RUSTC_VERSION=$(cat RUSTC_VERSION)
           echo "SRTOOL_VERSION=$SRTOOL_VERSION" >> $GITHUB_ENV
           echo "RUSTC_VERSION=$RUSTC_VERSION" >> $GITHUB_ENV
-      - name: Cache the image
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          key: srtool-docker-image-${{ github.sha }}
-          path: |
-            srtool.tar.gz
 
       - name: Install tera-cli
         run: |
@@ -98,12 +92,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: ["create_draft"]
     steps:
-      - name: Cache the image
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Download image artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          key: srtool-docker-image-${{ github.sha }}
-          path: |
-            srtool.tar.gz
+          name: srtool-image
 
       - name: Load Docker image
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: false
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Build image
         run: |
@@ -25,7 +25,7 @@ jobs:
           docker save srtool | gzip > srtool.tar.gz
 
       - name: Cache the image
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: srtool-docker-image-${{ github.sha }}
           path: |
@@ -39,7 +39,7 @@ jobs:
       release_url: ${{ steps.create-release.outputs.html_url }}
       asset_upload_url: ${{ steps.create-release.outputs.upload_url }}
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
       - name: Get Release Version
@@ -52,7 +52,7 @@ jobs:
           echo "SRTOOL_VERSION=$SRTOOL_VERSION" >> $GITHUB_ENV
           echo "RUSTC_VERSION=$RUSTC_VERSION" >> $GITHUB_ENV
       - name: Cache the image
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: srtool-docker-image-${{ github.sha }}
           path: |
@@ -99,7 +99,7 @@ jobs:
     needs: ["create_draft"]
     steps:
       - name: Cache the image
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: srtool-docker-image-${{ github.sha }}
           path: |
@@ -130,7 +130,7 @@ jobs:
           docker images
 
       - name: Log into Docker Hub
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee #v4.2.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: false
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -43,7 +43,7 @@ jobs:
           docker save srtool | gzip > srtool.tar.gz
 
       - name: Cache the image
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: srtool-docker-image-${{ github.sha }}
           path: |
@@ -55,7 +55,7 @@ jobs:
     continue-on-error: false
     steps:
       - name: Cache the image
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: srtool-docker-image-${{ github.sha }}
           path: |
@@ -85,7 +85,7 @@ jobs:
     needs: build
     continue-on-error: false
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -94,7 +94,7 @@ jobs:
           ls -al
 
       - name: Cache the image
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: srtool-docker-image-${{ github.sha }}
           path: |
@@ -133,7 +133,7 @@ jobs:
         chain: ["westend"]
     steps:
       - name: Cache the image
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: srtool-docker-image-${{ github.sha }}
           path: |
@@ -145,7 +145,7 @@ jobs:
           docker images --digests
 
       - name: Check out the Polkadot repo
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: paritytech/polkadot-sdk
           ref: ${{ github.event.inputs.ref }}
@@ -239,7 +239,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Archive Artifacts for ${{ matrix.chain }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.chain }}-runtime
           path: |
@@ -286,7 +286,7 @@ jobs:
 
     steps:
       - name: Cache the image
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: srtool-docker-image-${{ github.sha }}
           path: |
@@ -298,7 +298,7 @@ jobs:
           docker images --digests
 
       - name: Check out the Fellowship repo
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: polkadot-fellows/runtimes
           ref: ${{ github.event.inputs.ref }}
@@ -394,7 +394,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Archive Artifacts for ${{ matrix.chain }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.runtime }}
           path: |
@@ -418,7 +418,7 @@ jobs:
             chain: bridge-hub-westend
     steps:
       - name: Cache the image
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: srtool-docker-image-${{ github.sha }}
           path: |
@@ -430,7 +430,7 @@ jobs:
           docker images --digests
 
       - name: Check out the Cumulus repo
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: paritytech/polkadot-sdk
           ref: ${{ github.event.inputs.ref }}
@@ -511,7 +511,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Archive Artifacts for ${{ matrix.chain }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.chain }}-runtime
           path: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,24 +42,22 @@ jobs:
         run: |
           docker save srtool | gzip > srtool.tar.gz
 
-      - name: Cache the image
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Upload image artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          key: srtool-docker-image-${{ github.sha }}
-          path: |
-            srtool.tar.gz
+          name: srtool-image
+          path: srtool.tar.gz
+          retention-days: 1
 
   common:
     runs-on: ubuntu-latest
     needs: build
     continue-on-error: false
     steps:
-      - name: Cache the image
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Download image artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          key: srtool-docker-image-${{ github.sha }}
-          path: |
-            srtool.tar.gz
+          name: srtool-image
 
       - name: Load Docker image
         run: |
@@ -93,12 +91,10 @@ jobs:
         run: |
           ls -al
 
-      - name: Cache the image
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Download image artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          key: srtool-docker-image-${{ github.sha }}
-          path: |
-            srtool.tar.gz
+          name: srtool-image
 
       - name: Install tooling
         run: |
@@ -132,12 +128,10 @@ jobs:
       matrix:
         chain: ["westend"]
     steps:
-      - name: Cache the image
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Download image artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          key: srtool-docker-image-${{ github.sha }}
-          path: |
-            srtool.tar.gz
+          name: srtool-image
 
       - name: Load Docker image
         run: |
@@ -285,12 +279,10 @@ jobs:
             chain: collectives-polkadot
 
     steps:
-      - name: Cache the image
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Download image artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          key: srtool-docker-image-${{ github.sha }}
-          path: |
-            srtool.tar.gz
+          name: srtool-image
 
       - name: Load Docker image
         run: |
@@ -417,12 +409,10 @@ jobs:
           - category: bridge-hubs
             chain: bridge-hub-westend
     steps:
-      - name: Cache the image
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Download image artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          key: srtool-docker-image-${{ github.sha }}
-          path: |
-            srtool.tar.gz
+          name: srtool-image
 
       - name: Load Docker image
         run: |


### PR DESCRIPTION
  ### The fix in manual-polkadot-sdk.yml
  - Dynamic tag (no hardcoding): new Determine the SRTOOL tag step in find-runtimes uses
  `github.event.inputs.srtool_tag` if set, else cat `srtool/RUSTC_VERSION`; exposed as a job output and consumed as tag: 
  `${{ needs.find-runtimes.outputs.srtool_tag }}`.
  - Other empty-on-schedule inputs given defaults: `image`, `profile`, `build_opts`, and the inputs.profile cache/artifact
  paths (concurrently set to production).

 ###  Version bumps (all workflows, pinned by SHA)
  - actions/checkout → v6.0.3
  - actions/cache → v5.0.5
  - actions/upload-artifact → v7.0.1
  - docker/login-action → v4.2.0 (release.yml, via the concurrent edits)